### PR TITLE
On ExpenseTag change bug fix

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/banko/app/domain/AssignExpenseTagToTransactionUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/domain/AssignExpenseTagToTransactionUseCase.kt
@@ -2,18 +2,22 @@ package com.banko.app.domain
 
 import com.banko.app.DatabaseExpenseTagRepository
 import com.banko.app.DatabaseTransactionRepository
+import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
+import kotlinx.coroutines.flow.firstOrNull
 
 class AssignExpenseTagToTransactionUseCase(
     private val transactionRepository: DatabaseTransactionRepository,
     private val expenseTagRepository: DatabaseExpenseTagRepository
 ) {
     suspend operator fun invoke(transactionId: String, expenseTagId: String?) {
-        val transaction = transactionRepository.findRawTransactionById(transactionId) ?: return
-        expenseTagRepository.findExpenseTagById(expenseTagId).collect { tag ->
-            transactionRepository.upsertTransaction(
-                transaction = transaction.copy(expenseTagId = tag?.id),
-                expenseTag = tag
-            )
-        }
+        val transaction = transactionRepository.findRawTransactionById(transactionId)
+            ?: error("no transaction in db with id $transactionId")
+        val tag = expenseTagRepository.findExpenseTagById(expenseTagId).first()
+            ?: error("no expense tag found in db with id $expenseTagId")
+        transactionRepository.upsertTransaction(
+            transaction = transaction.copy(expenseTagId = tag.id),
+            expenseTag = tag
+        )
     }
 }


### PR DESCRIPTION
## What

- Fixed the usecase to update the Expense Tag on DB form the transaction detail screen

## Why 

- After updating the the expense tag more than once the main screen was experiencing a flickering change of color on the transaction row where the tag was changed