### PR TITLE
Year view toggle, unified data loading, and pull-to-load-more on timespan bar

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -57,5 +57,7 @@
     <string name="monthly_budget">Monthly Budget</string>>
     <string name="monthly_income">Money Saved This Month:</string>
     <string name="saved_money_yesterday">Money Saved Yesterday:</string>
+    <string name="yearly_spendings">Yearly Spendings</string>
+    <string name="yearly_earnings">Yearly Earnings</string>
     <string name="settings">Settings</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/CircularIndicator.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/CircularIndicator.kt
@@ -37,12 +37,13 @@ import androidx.compose.ui.unit.dp
 import banko.composeapp.generated.resources.Res
 import banko.composeapp.generated.resources.monthly_earnings
 import banko.composeapp.generated.resources.monthly_spendings
+import banko.composeapp.generated.resources.yearly_earnings
+import banko.composeapp.generated.resources.yearly_spendings
 import com.banko.app.ModelTransaction
 import com.banko.app.ui.models.Category
 import com.banko.app.ui.models.Transaction
-import com.banko.app.ui.screens.home.HomeScreenState
+import com.banko.app.ui.screens.home.TimespanSelection
 import com.banko.app.ui.theme.Grey_Nevada
-import kotlinx.datetime.LocalDateTime
 import kotlinx.datetime.Month
 import org.jetbrains.compose.resources.stringResource
 import kotlin.math.roundToLong
@@ -50,46 +51,66 @@ import kotlin.math.roundToLong
 @Composable
 fun CircularIndicator(
     currency: String,
-    monthlyTransactions: List<ModelTransaction>,
+    transactions: List<ModelTransaction>,
+    selectedTimespan: TimespanSelection,
     bigTextFontSize: TextUnit = MaterialTheme.typography.bodyLarge.fontSize,
     bigTextColor: Color = MaterialTheme.colorScheme.primary,
     canvasSize: Dp = 256.dp,
     indicatorStroke: Float = 60f,
     smallTextColor: Color = MaterialTheme.colorScheme.primary.copy(alpha = 0.5f),
     smallTextFontSize: TextUnit = MaterialTheme.typography.bodyMedium.fontSize,
-    indicatorDateState: LocalDateTime
 ) {
-    val monthlySpending = monthlyTransactions.filter {
-        it.bookingDate.month == indicatorDateState.month && it.expenseTag?.isEarning != true
+    val (transactionsInRange, isYearView) = when (selectedTimespan) {
+        is TimespanSelection.Month -> {
+            Pair(
+                transactions.filter {
+                    it.bookingDate.monthNumber == selectedTimespan.ym.month &&
+                            it.bookingDate.year == selectedTimespan.ym.year
+                },
+                false
+            )
+        }
+        is TimespanSelection.Year -> {
+            Pair(
+                transactions.filter { it.bookingDate.year == selectedTimespan.year },
+                true
+            )
+        }
+    }
+
+    val totalSpending = transactionsInRange.filter {
+        it.expenseTag?.isEarning != true
     }.sumOf { it.amount }.toInt()
-    val monthlyEarnings = monthlyTransactions.filter {
-        it.bookingDate.month == indicatorDateState.month && it.expenseTag?.isEarning == true
+    val totalEarnings = transactionsInRange.filter {
+        it.expenseTag?.isEarning == true
     }.sumOf { it.amount }.toInt()
-    val categories = sortCategories(monthlyTransactions, month = indicatorDateState.month)
+    val categories = when (selectedTimespan) {
+        is TimespanSelection.Month -> sortCategories(transactions, month = Month(selectedTimespan.ym.month))
+        is TimespanSelection.Year -> sortCategories(transactions, year = selectedTimespan.year)
+    }
     val totalAmount = categories.sumOf { it.amount.toInt() }.toFloat()
-    var animatedMonthlyBudgetValue by remember { mutableIntStateOf(0) }
-    var animatedMonthlySpendingsValue by remember { mutableIntStateOf(0) }
+    var animatedEarningsValue by remember { mutableIntStateOf(0) }
+    var animatedSpendingsValue by remember { mutableIntStateOf(0) }
 
-    LaunchedEffect(monthlyEarnings) {
-        animatedMonthlyBudgetValue = monthlyEarnings
+    LaunchedEffect(totalEarnings) {
+        animatedEarningsValue = totalEarnings
     }
-    LaunchedEffect(monthlySpending) {
-        animatedMonthlySpendingsValue = monthlySpending
+    LaunchedEffect(totalSpending) {
+        animatedSpendingsValue = totalSpending
     }
 
-    val animatedMonthlySpendings by animateIntAsState(
-        targetValue = animatedMonthlySpendingsValue,
+    val animatedSpendings by animateIntAsState(
+        targetValue = animatedSpendingsValue,
         animationSpec = tween(1000),
         label = ""
     )
 
-    val animatedMonthlyBudget by animateIntAsState(
-        targetValue = animatedMonthlyBudgetValue,
+    val animatedEarnings by animateIntAsState(
+        targetValue = animatedEarningsValue,
         animationSpec = tween(1000),
         label = ""
     )
 
-    // Remember and animate the sweep angles for each category
     val animatedSweepAngles = categories.mapIndexed { index, category ->
         animateFloatAsState(
             targetValue = (category.amount.toInt() / totalAmount) * 240f,
@@ -97,6 +118,9 @@ fun CircularIndicator(
             label = ""
         ).value
     }
+
+    val spendingsLabel = if (isYearView) stringResource(Res.string.yearly_spendings) else stringResource(Res.string.monthly_spendings)
+    val earningsLabel = if (isYearView) stringResource(Res.string.yearly_earnings) else stringResource(Res.string.monthly_earnings)
 
     Column(
         verticalArrangement = Arrangement.Center,
@@ -115,7 +139,7 @@ fun CircularIndicator(
                     foregroundIndicator(
                         categories = categories,
                         animatedSweepAngles = animatedSweepAngles,
-                        startAngle = 150f, // È il punto da cui parte il tag
+                        startAngle = 150f,
                         componentSize = componentSize,
                         indicatorStroke = indicatorStroke,
                     )
@@ -124,13 +148,13 @@ fun CircularIndicator(
             horizontalAlignment = Alignment.CenterHorizontally
         ) {
             EmbeddedElements(
-                dailyBudget = animatedMonthlySpendings,
-                monthlyBudget = animatedMonthlyBudget,
+                dailyBudget = animatedSpendings,
+                monthlyBudget = animatedEarnings,
                 bigTextFontSize = bigTextFontSize,
                 bigTextColor = bigTextColor,
                 currency = currency,
-                monthlySpendings = stringResource(Res.string.monthly_spendings),
-                monthlyEarnings = stringResource(Res.string.monthly_earnings),
+                monthlySpendings = spendingsLabel,
+                monthlyEarnings = earningsLabel,
                 smallTextColor = smallTextColor,
                 smallTextFontSize = smallTextFontSize,
             )
@@ -240,7 +264,6 @@ private fun CategoryGrid(categories: List<Category>, itemsPerRow: Int = 5) {
             .fillMaxWidth().offset(y = (-30).dp),
         verticalArrangement = Arrangement.spacedBy(8.dp)
     ) {
-        // Break the list into chunks of `itemsPerRow`
         categories.chunked(itemsPerRow).forEach { rowCategories ->
             Row(
                 modifier = Modifier
@@ -279,9 +302,23 @@ private fun CategoryGrid(categories: List<Category>, itemsPerRow: Int = 5) {
     }
 }
 
-private fun sortCategories(transactions: List<ModelTransaction>, month: Month): List<Category> {
+private fun sortCategories(transactions: List<ModelTransaction>, month: kotlinx.datetime.Month): List<Category> {
     val result =
         transactions.filter { it.expenseTag != null && it.bookingDate.month == month && it.expenseTag.name != "Salary" }
+    return result.groupBy { it.expenseTag }.map {
+        val sum = it.value.sumOf { it.amount }
+        val roundedAmount = (sum * 100).roundToLong() / 100.0
+        Category(
+            name = it.key!!.name,
+            amount = roundedAmount,
+            color = it.key!!.color
+        )
+    }
+}
+
+private fun sortCategories(transactions: List<ModelTransaction>, year: Int): List<Category> {
+    val result =
+        transactions.filter { it.expenseTag != null && it.bookingDate.year == year && it.expenseTag.name != "Salary" }
     return result.groupBy { it.expenseTag }.map {
         val sum = it.value.sumOf { it.amount }
         val roundedAmount = (sum * 100).roundToLong() / 100.0

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreen.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.core.LinearEasing
 import androidx.compose.animation.core.RepeatMode
 import androidx.compose.animation.core.animateFloat
+import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.infiniteRepeatable
 import androidx.compose.animation.core.rememberInfiniteTransition
 import androidx.compose.animation.core.tween
@@ -21,6 +22,7 @@ import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.BoxWithConstraints
+import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
@@ -39,9 +41,11 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.Switch
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
@@ -49,6 +53,8 @@ import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.State
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
@@ -59,10 +65,16 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.draw.alpha
+import androidx.compose.ui.draw.scale
+import androidx.compose.ui.input.nestedscroll.NestedScrollConnection
+import androidx.compose.ui.input.nestedscroll.NestedScrollSource
+import androidx.compose.ui.input.nestedscroll.nestedScroll
 import androidx.compose.ui.input.pointer.pointerInput
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import banko.composeapp.generated.resources.Res
 import banko.composeapp.generated.resources.app_name
@@ -94,7 +106,9 @@ fun HomeScreen(component: HomeComponent) {
         onTimespanSelected = { viewModel.handleEvent(TransactionsEvent.SelectTimespan(it)) },
         onRefresh = { viewModel.handleEvent(event = TransactionsEvent.Refresh) },
         clearError = { viewModel.handleEvent(TransactionsEvent.ErrorShown(it)) },
-        onDeleteTransaction = { viewModel.handleEvent(TransactionsEvent.DeleteTransaction(it)) }
+        onDeleteTransaction = { viewModel.handleEvent(TransactionsEvent.DeleteTransaction(it)) },
+        onToggleView = { viewModel.handleEvent(TransactionsEvent.ToggleTimespanView) },
+        onLoadMore = { viewModel.handleEvent(TransactionsEvent.LoadMore) }
     )
 }
 
@@ -105,7 +119,9 @@ fun HomeScreen(
     onTimespanSelected: (TimespanSelection) -> Unit,
     onRefresh: () -> Unit,
     clearError: (String) -> Unit,
-    onDeleteTransaction: (String) -> Unit
+    onDeleteTransaction: (String) -> Unit,
+    onToggleView: () -> Unit,
+    onLoadMore: () -> Unit
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
     var dragOffset by remember { mutableStateOf(0f) }
@@ -126,17 +142,26 @@ fun HomeScreen(
         TimespanBar(
             selectedTimespan = state.value.selectedTimespan,
             availableMonths = state.value.availableMonths,
-            onTimespanSelected = onTimespanSelected
+            availableYears = state.value.availableYears,
+            isYearView = state.value.isYearView,
+            onTimespanSelected = onTimespanSelected,
+            isLoadingMore = state.value.isLoadingMore,
+            onToggleView = onToggleView,
+            onLoadMore = onLoadMore
         )
         ExpandableCard(
             isExpanded = true,
             topContent = {},
             expandedContent = {
                 AnimatedContent(
-                    targetState = state.value.indicatorDateState,
+                    targetState = state.value.selectedTimespan,
                     transitionSpec = {
-                        val target = targetState.year * 12 + targetState.monthNumber
-                        val initial = initialState.year * 12 + initialState.monthNumber
+                        fun TimespanSelection.weight(): Int = when (this) {
+                            is TimespanSelection.Month -> ym.year * 12 + ym.month
+                            is TimespanSelection.Year -> year * 12 + 6
+                        }
+                        val target = targetState.weight()
+                        val initial = initialState.weight()
                         if (target > initial) {
                             slideInHorizontally { width -> -width } + fadeIn() togetherWith
                             slideOutHorizontally { width -> width } + fadeOut()
@@ -159,34 +184,55 @@ fun HomeScreen(
                                     },
                                     onDragEnd = {
                                         val current = state.value
-                                        val sel = current.selectedTimespan as TimespanSelection.Month
-                                        when {
-                                            dragOffset < -swipeThreshold -> {
-                                                val idx = current.availableMonths.indexOf(sel.ym)
-                                                if (idx < current.availableMonths.size - 1) {
-                                                    onTimespanSelected(TimespanSelection.Month(current.availableMonths[idx + 1]))
+                                        when (val sel = current.selectedTimespan) {
+                                            is TimespanSelection.Month -> {
+                                                when {
+                                                    dragOffset < -swipeThreshold -> {
+                                                        val idx = current.availableMonths.indexOf(sel.ym)
+                                                        if (idx < current.availableMonths.size - 1) {
+                                                            onTimespanSelected(TimespanSelection.Month(current.availableMonths[idx + 1]))
+                                                        }
+                                                    }
+                                                    dragOffset > swipeThreshold -> {
+                                                        val idx = current.availableMonths.indexOf(sel.ym)
+                                                        if (idx > 0) {
+                                                            onTimespanSelected(TimespanSelection.Month(current.availableMonths[idx - 1]))
+                                                        }
+                                                    }
                                                 }
                                             }
-                                            dragOffset > swipeThreshold -> {
-                                                val idx = current.availableMonths.indexOf(sel.ym)
-                                                if (idx > 0) {
-                                                    onTimespanSelected(TimespanSelection.Month(current.availableMonths[idx - 1]))
+                                            is TimespanSelection.Year -> {
+                                                when {
+                                                    dragOffset < -swipeThreshold -> {
+                                                        val idx = current.availableYears.indexOf(sel.year)
+                                                        if (idx < current.availableYears.size - 1) {
+                                                            onTimespanSelected(TimespanSelection.Year(current.availableYears[idx + 1]))
+                                                        }
+                                                    }
+                                                    dragOffset > swipeThreshold -> {
+                                                        val idx = current.availableYears.indexOf(sel.year)
+                                                        if (idx > 0) {
+                                                            onTimespanSelected(TimespanSelection.Year(current.availableYears[idx - 1]))
+                                                        }
+                                                    }
                                                 }
                                             }
                                         }
+                                        dragOffset = 0f
                                     }
                                 )
                             }
                     ) {
                         CircularIndicator(
                             currency = stringResource(Res.string.currency_nok),
-                            monthlyTransactions = state.value.transactions,
-                            indicatorDateState = state.value.indicatorDateState
+                            transactions = state.value.transactions,
+                            selectedTimespan = state.value.selectedTimespan
                         )
                     }
                 }
             }
         )
+        LoadingProgressIndicator(isLoading = state.value.isLoadingMore)
         Scaffold(
             snackbarHost = { SnackbarHost(snackbarHostState) }
         ) { padding ->
@@ -362,29 +408,130 @@ private fun TopContent() {
 private fun TimespanBar(
     selectedTimespan: TimespanSelection,
     availableMonths: List<YearMonth>,
-    onTimespanSelected: (TimespanSelection) -> Unit
+    availableYears: List<Int>,
+    isYearView: Boolean,
+    isLoadingMore: Boolean,
+    onTimespanSelected: (TimespanSelection) -> Unit,
+    onToggleView: () -> Unit,
+    onLoadMore: () -> Unit
 ) {
     val listState = rememberLazyListState()
+    var overscrollOffset by remember { mutableFloatStateOf(0f) }
+    val overscrollThreshold = 100f
 
-    LaunchedEffect(selectedTimespan, availableMonths.size) {
-        val ym = (selectedTimespan as? TimespanSelection.Month)?.ym
-        val index = availableMonths.indexOf(ym)
-        if (index == -1) return@LaunchedEffect
-        listState.animateScrollToItem(index)
+    val isAtEnd by remember {
+        derivedStateOf {
+            val layoutInfo = listState.layoutInfo
+            val lastVisible = layoutInfo.visibleItemsInfo.lastOrNull()
+            lastVisible != null && lastVisible.index == layoutInfo.totalItemsCount - 1
+        }
     }
 
-    LazyRow(
-        state = listState,
+    val nestedScrollConnection = remember(isAtEnd, isLoadingMore, overscrollThreshold) {
+        object : NestedScrollConnection {
+            override fun onPostScroll(consumed: Offset, available: Offset, source: NestedScrollSource): Offset {
+                if (isAtEnd && !isLoadingMore && source == NestedScrollSource.UserInput) {
+                    val overscroll = -available.x
+                    if (overscroll > 0) {
+                        overscrollOffset = (overscrollOffset + overscroll).coerceAtMost(overscrollThreshold)
+                        return Offset(available.x, 0f)
+                    }
+                }
+                return Offset.Zero
+            }
+
+            override suspend fun onPostFling(consumed: Velocity, available: Velocity): Velocity {
+                if (isAtEnd && overscrollOffset >= overscrollThreshold && !isLoadingMore) {
+                    onLoadMore()
+                }
+                overscrollOffset = 0f
+                return Velocity.Zero
+            }
+        }
+    }
+
+    LaunchedEffect(selectedTimespan, isYearView) {
+        overscrollOffset = 0f
+        val index = when (val sel = selectedTimespan) {
+            is TimespanSelection.Month -> availableMonths.indexOf(sel.ym)
+            is TimespanSelection.Year -> availableYears.indexOf(sel.year)
+        }
+        if (index != -1) {
+            listState.animateScrollToItem(index)
+        }
+    }
+
+    Row(
         modifier = Modifier.fillMaxWidth(),
-        horizontalArrangement = Arrangement.spacedBy(8.dp),
-        contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
+        verticalAlignment = Alignment.CenterVertically
     ) {
-        items(availableMonths) { ym ->
-            val monthName = Month(ym.month).name.take(3)
-            MonthChip(
-                label = "$monthName ${ym.year}",
-                selected = (selectedTimespan as? TimespanSelection.Month)?.ym == ym,
-                onClick = { onTimespanSelected(TimespanSelection.Month(ym)) }
+        LazyRow(
+            state = listState,
+            modifier = Modifier
+                .weight(1f)
+                .nestedScroll(nestedScrollConnection),
+            horizontalArrangement = Arrangement.spacedBy(8.dp),
+            contentPadding = PaddingValues(horizontal = 16.dp, vertical = 8.dp)
+        ) {
+            if (isYearView) {
+                items(availableYears, key = { it }) { year ->
+                    MonthChip(
+                        label = year.toString(),
+                        selected = (selectedTimespan as? TimespanSelection.Year)?.year == year,
+                        onClick = { onTimespanSelected(TimespanSelection.Year(year)) }
+                    )
+                }
+            } else {
+                items(availableMonths) { ym ->
+                    val monthName = Month(ym.month).name.take(3)
+                    MonthChip(
+                        label = "$monthName ${ym.year}",
+                        selected = (selectedTimespan as? TimespanSelection.Month)?.ym == ym,
+                        onClick = { onTimespanSelected(TimespanSelection.Month(ym)) }
+                    )
+                }
+            }
+        }
+
+        val pullProgress = (overscrollOffset / overscrollThreshold).coerceIn(0f, 1f)
+        if (pullProgress > 0f && !isLoadingMore) {
+            val indicatorAlpha by animateFloatAsState(
+                targetValue = pullProgress.coerceIn(0.3f, 1f),
+                animationSpec = tween(durationMillis = 300)
+            )
+            Box(
+                modifier = Modifier
+                    .size(24.dp)
+                    .padding(end = 4.dp)
+                    .alpha(indicatorAlpha)
+            ) {
+                CircularProgressIndicator(
+                    modifier = Modifier.size(20.dp),
+                    strokeWidth = 2.dp,
+                    progress = pullProgress
+                )
+            }
+        }
+
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier
+                .padding(start = 0.dp, end = 0.dp, top = 8.dp, bottom = 8.dp)
+                .background(
+                    color = MaterialTheme.colorScheme.onSurface.copy(alpha = 0.06f),
+                    shape = RoundedCornerShape(20.dp)
+                )
+                .padding(horizontal = 8.dp)
+        ) {
+            Text(
+                text = if (isYearView) "Year" else "Month",
+                style = MaterialTheme.typography.bodySmall,
+                color = MaterialTheme.colorScheme.primary
+            )
+            Switch(
+                checked = isYearView,
+                onCheckedChange = { onToggleView() },
+                modifier = Modifier.scale(0.7f)
             )
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenState.kt
@@ -2,12 +2,26 @@ package com.banko.app.ui.screens.home
 
 import com.banko.app.ModelTransaction
 import com.banko.app.utils.beginningOfCurrentMonth
+import com.banko.app.utils.computeYearEndDate
+import com.banko.app.utils.getLastDayOfMonth
+import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 
 data class YearMonth(val year: Int, val month: Int)
 
 sealed class TimespanSelection {
-    data class Month(val ym: YearMonth) : TimespanSelection()
+    abstract val fromDate: LocalDate
+    abstract val toDate: LocalDate
+
+    data class Month(val ym: YearMonth) : TimespanSelection() {
+        override val fromDate: LocalDate = LocalDate(ym.year, ym.month, 1)
+        override val toDate: LocalDate = LocalDate(ym.year, ym.month, getLastDayOfMonth(ym.year, ym.month))
+    }
+
+    data class Year(val year: Int) : TimespanSelection() {
+        override val fromDate: LocalDate = LocalDate(year, 1, 1)
+        override val toDate: LocalDate = computeYearEndDate(year)
+    }
 }
 
 data class HomeScreenState(
@@ -18,7 +32,10 @@ data class HomeScreenState(
     val indicatorDateState: LocalDateTime = beginningOfCurrentMonth(),
     val selectedTimespan: TimespanSelection = TimespanSelection.Month(YearMonth(beginningOfCurrentMonth().year, beginningOfCurrentMonth().monthNumber)),
     val availableMonths: List<YearMonth> = emptyList(),
+    val availableYears: List<Int> = emptyList(),
+    val isYearView: Boolean = false,
     val isSyncing: Boolean = false,
+    val isLoadingMore: Boolean = false,
 )
 
 sealed class TransactionsEvent {
@@ -26,4 +43,6 @@ sealed class TransactionsEvent {
     data class ErrorShown(val error: String) : TransactionsEvent()
     data class DeleteTransaction(val transactionId: String) : TransactionsEvent()
     data class SelectTimespan(val timespan: TimespanSelection) : TransactionsEvent()
+    data object ToggleTimespanView : TransactionsEvent()
+    data object LoadMore : TransactionsEvent()
 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenViewModel.kt
@@ -5,7 +5,8 @@ import androidx.lifecycle.viewModelScope
 import com.banko.app.domain.repository.TransactionRepository
 import com.banko.app.ui.models.toUi
 import com.banko.app.utils.beginningOfCurrentMonth
-import com.banko.app.utils.monthRange
+import com.banko.app.utils.computeYearEndDate
+import com.banko.app.utils.getLastDayOfMonth
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
@@ -27,6 +28,7 @@ class HomeScreenViewModel(
 
     private var transactionsJob: Job? = null
     private var syncJob: Job? = null
+    private var lastMonthSelection: YearMonth? = null
 
     init {
         initializeTimespanSelection()
@@ -44,6 +46,8 @@ class HomeScreenViewModel(
             is TransactionsEvent.ErrorShown -> clearError(event.error)
             is TransactionsEvent.DeleteTransaction -> handleDeleteTransaction(event.transactionId)
             is TransactionsEvent.SelectTimespan -> handleSelectTimespan(event.timespan)
+            is TransactionsEvent.ToggleTimespanView -> handleToggleView()
+            is TransactionsEvent.LoadMore -> handleLoadMore()
         }
     }
 
@@ -51,10 +55,8 @@ class HomeScreenViewModel(
         viewModelScope.launch {
             _state.update { it.copy(isRefreshing = true) }
             try {
-                val state = _state.value
-                val sel = state.selectedTimespan as TimespanSelection.Month
-                val (fromDate, toDate) = monthRange(sel.ym.year, sel.ym.month)
-                repository.fetchAndStoreTransactionsForDateRange(fromDate, toDate)
+                val sel = _state.value.selectedTimespan
+                repository.fetchAndStoreTransactionsForDateRange(sel.fromDate, sel.toDate)
                 loadTransactionsForCurrentSelection()
             } catch (_: Exception) {
                 _state.update { it.copy(isRefreshing = false) }
@@ -92,7 +94,8 @@ class HomeScreenViewModel(
             // Show cached DB data immediately
             val oldestDate = repository.getOldestTransactions()
             val months = generateMonthRange(oldestDate)
-            _state.update { it.copy(availableMonths = months) }
+            val years = months.map { it.year }.distinct().sortedDescending()
+            _state.update { it.copy(availableMonths = months, availableYears = years) }
             loadTransactionsForCurrentSelection()
 
             // Sync in background — never block screen init
@@ -116,7 +119,8 @@ class HomeScreenViewModel(
 
             val refreshedOldestDate = repository.getOldestTransactions()
             val refreshedMonths = generateMonthRange(refreshedOldestDate)
-            _state.update { it.copy(availableMonths = refreshedMonths) }
+            val refreshedYears = refreshedMonths.map { it.year }.distinct().sortedDescending()
+            _state.update { it.copy(availableMonths = refreshedMonths, availableYears = refreshedYears) }
         } catch (_: Exception) { }
     }
 
@@ -124,10 +128,8 @@ class HomeScreenViewModel(
         val state = _state.value
         transactionsJob?.cancel()
 
-        val sel = state.selectedTimespan as TimespanSelection.Month
-        val (fromDate, toDate) = monthRange(sel.ym.year, sel.ym.month)
-
-        transactionsJob = repository.getTransactionsForDateRange(fromDate, toDate)
+        val sel = state.selectedTimespan
+        transactionsJob = repository.getTransactionsForDateRange(sel.fromDate, sel.toDate)
             .map { list -> list.map { it.toUi() } }
             .onEach { transactions ->
                 _state.update {
@@ -146,15 +148,14 @@ class HomeScreenViewModel(
     }
 
     private suspend fun performBackgroundSync() {
-        val state = _state.value
-        val sel = state.selectedTimespan as TimespanSelection.Month
-        val (fromDate, toDate) = monthRange(sel.ym.year, sel.ym.month)
+        val sel = _state.value.selectedTimespan
         try {
-            repository.fetchAndStoreTransactionsForDateRange(fromDate, toDate)
+            repository.fetchAndStoreTransactionsForDateRange(sel.fromDate, sel.toDate)
             val oldestDate = repository.getOldestTransactions()
             val months = generateMonthRange(oldestDate)
             if (months.size > _state.value.availableMonths.size) {
-                _state.update { it.copy(availableMonths = months) }
+                val years = months.map { it.year }.distinct().sortedDescending()
+                _state.update { it.copy(availableMonths = months, availableYears = years) }
             }
         } catch (_: Exception) {
             // silent background sync failure
@@ -162,17 +163,81 @@ class HomeScreenViewModel(
     }
 
     private fun handleSelectTimespan(timespan: TimespanSelection) {
-        val monthTimespan = timespan as TimespanSelection.Month
-        _state.update {
-            it.copy(
-                selectedTimespan = timespan,
-                indicatorDateState = LocalDateTime(
-                    monthTimespan.ym.year, monthTimespan.ym.month, 1, 0, 0
-                )
-            )
+        when (timespan) {
+            is TimespanSelection.Month -> {
+                lastMonthSelection = timespan.ym
+                _state.update {
+                    it.copy(
+                        selectedTimespan = timespan,
+                        indicatorDateState = LocalDateTime(timespan.ym.year, timespan.ym.month, 1, 0, 0),
+                        isYearView = false
+                    )
+                }
+            }
+            is TimespanSelection.Year -> {
+                _state.update {
+                    it.copy(
+                        selectedTimespan = timespan,
+                        indicatorDateState = LocalDateTime(timespan.year, 1, 1, 0, 0),
+                        isYearView = true
+                    )
+                }
+            }
         }
         loadTransactionsForCurrentSelection()
         scheduleBackgroundSync()
+    }
+
+    private fun handleToggleView() {
+        val state = _state.value
+        if (state.isYearView) {
+            val month = lastMonthSelection ?: YearMonth(
+                beginningOfCurrentMonth().year,
+                beginningOfCurrentMonth().monthNumber
+            )
+            handleSelectTimespan(TimespanSelection.Month(month))
+        } else {
+            val ym = (state.selectedTimespan as? TimespanSelection.Month)?.ym
+                ?: YearMonth(beginningOfCurrentMonth().year, beginningOfCurrentMonth().monthNumber)
+            lastMonthSelection = ym
+            handleSelectTimespan(TimespanSelection.Year(ym.year))
+        }
+    }
+
+    private fun handleLoadMore() {
+        val currentState = _state.value
+        if (currentState.isLoadingMore) return
+
+        _state.update { it.copy(isLoadingMore = true) }
+        viewModelScope.launch {
+            try {
+                val s = _state.value
+                val (fromDate, toDate) = if (s.isYearView) {
+                    val oldestYear = s.availableYears.last()
+                    LocalDate(oldestYear - 1, 1, 1) to computeYearEndDate(oldestYear - 1)
+                } else {
+                    val oldestMonth = s.availableMonths.last()
+                    val prevYear = if (oldestMonth.month == 1) oldestMonth.year - 1 else oldestMonth.year
+                    val prevMonth = if (oldestMonth.month == 1) 12 else oldestMonth.month - 1
+                    LocalDate(prevYear, prevMonth, 1) to LocalDate(prevYear, prevMonth, getLastDayOfMonth(prevYear, prevMonth))
+                }
+
+                repository.fetchAndStoreTransactionsForDateRange(fromDate, toDate)
+
+                val refreshedOldestDate = repository.getOldestTransactions()
+                val refreshedMonths = generateMonthRange(refreshedOldestDate)
+                val refreshedYears = refreshedMonths.map { it.year }.distinct().sortedDescending()
+                _state.update {
+                    it.copy(
+                        availableMonths = refreshedMonths,
+                        availableYears = refreshedYears,
+                        isLoadingMore = false
+                    )
+                }
+            } catch (_: Exception) {
+                _state.update { it.copy(isLoadingMore = false) }
+            }
+        }
     }
 
     private fun generateMonthRange(from: LocalDateTime): List<YearMonth> {

--- a/composeApp/src/commonMain/kotlin/com/banko/app/utils/DateTimeUtils.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/utils/DateTimeUtils.kt
@@ -27,6 +27,11 @@ fun monthRange(year: Int, month: Int): Pair<LocalDate, LocalDate> {
     return fromDate to toDate
 }
 
+fun computeYearEndDate(year: Int): LocalDate {
+    val today = Clock.System.now().toLocalDateTime(TimeZone.currentSystemDefault()).date
+    return if (year == today.year) today else LocalDate(year, 12, 31)
+}
+
 fun getLastDayOfMonth(year: Int, month: Int): Int {
     val firstDayOfThisMonth = LocalDate(year, month, 1)
     val firstDayOfNextMonth = firstDayOfThisMonth.plus(DatePeriod(months = 1))


### PR DESCRIPTION
## What
- Added a Year variant to TimespanSelection with auto-computed date ranges
- Added a toggle switch to switch between month and year views on the timespan bar
Year chips show "2026", month chips show "JUN 2026"
- The CircularIndicator (donut chart) is now year-aware, filtering transactions by the selected period
- Unified the ViewModel data loading so both month and year views use the same fromDate / toDate path
- Added pull-to-load-more on the timespan bar — dragging at the right end past the last chip fetches older data (previous month or previous year)
- Pull feedback: a determinate CircularProgressIndicator fades in during the drag; once the threshold is crossed, a gradient line animation runs on top of the transaction list during the fetch
- Background sync now fetches 3 years of data on first launch

## Why
- Previously the app only supported month-level date ranges; a Year variant was needed to represent full-year periods without manual computation
- Users need a quick way to switch between monthly and yearly perspectives without navigating away
- Clear visual distinction between the two view modes helps the user understand which period is selected
- The spending breakdown must reflect the currently selected timespan, whether month or year
- Removes branching logic in the ViewModel and Repository — the selection carries its own date range, keeping the data layer view-agnostic
- Users can load older transactions without manual pagination, in either view mode
- Gives clear visual feedback during both the pull phase (progress toward trigger) and the loading phase (fetch in progress)
- Ensures sufficient historical data is available for both month and year views without requiring multiple pull-to-load-more actions
