### PR TITLE
Fix ExpenseTagRepository.deleteExpenseTag hanging on Room Flow collect

### DIFF
--- a/composeApp/src/androidUnitTest/kotlin/com/banko/app/database/repository/ExpenseTagRepositoryTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/banko/app/database/repository/ExpenseTagRepositoryTest.kt
@@ -113,7 +113,7 @@ class ExpenseTagRepositoryTest {
         repo.upsertExpenseTag(tag)
         assertEquals(1, db.bankoDao().getAllExpenseTags().first().size)
 
-        db.bankoDao().deleteExpenseTag(tag)
+        repo.deleteExpenseTag("tag-1")
 
         assertEquals(0, db.bankoDao().getAllExpenseTags().first().size)
     }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/database/repository/ExpenseTagRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/database/repository/ExpenseTagRepository.kt
@@ -3,6 +3,7 @@ package com.banko.app.database.repository
 import com.banko.app.database.BankoDatabase
 import com.banko.app.database.Entities.ExpenseTag
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.flowOf
 
 class ExpenseTagRepository(
@@ -17,10 +18,8 @@ class ExpenseTagRepository(
     }
 
     suspend fun deleteExpenseTag(expenseTagId: String) {
-        dao.getExpenseTagById(expenseTagId).collect { expenseTag ->
-            expenseTag ?: return@collect
-            dao.deleteExpenseTag(expenseTag = expenseTag)
-        }
+        val expenseTag = dao.getExpenseTagById(expenseTagId).first() ?: return
+        dao.deleteExpenseTag(expenseTag = expenseTag)
     }
 
     suspend fun findExpenseTagById(expenseTagId: String?): Flow<ExpenseTag?> {


### PR DESCRIPTION
## What
- Replace `.collect {}` with `.first()` in `ExpenseTagRepository.deleteExpenseTag`
- Update test to call `repo.deleteExpenseTag()` instead of `dao.deleteExpenseTag()`

## Why
- Room Flows never complete, so `.collect {}` suspends forever — the delete runs but the caller hangs, freezing the Settings screen
- The previous test bypassed the repository method entirely, masking the bug and providing no regression protection