### PR TITLE
Add sync cooldown to prevent redundant background API calls

### DIFF
--- a/AGENT_INSTRUCTIONS.md
+++ b/AGENT_INSTRUCTIONS.md
@@ -28,3 +28,28 @@ This file gives an AI agent a quick overview of where the Banko project code liv
 
 Always consider all Banko-related repositories together. Do not assume the current repo contains the full context.
 Never commit anything if you didn't receive an approval for that.
+
+## Pull Request Format
+
+When creating a Pull Request description, always use the following structure:
+
+## What
+- Change 1
+- Change 2
+- Change 3
+
+## Why
+- Reason for Change 1
+- Reason for Change 2
+- Reason for Change 3
+
+Rules:
+- The description must contain exactly two sections: `## What` and `## Why`.
+- Both sections must use bullet lists.
+- `## What` describes the actual changes introduced by the PR.
+- `## Why` explains the motivation, business value, bug fix, technical reason, or user benefit behind each corresponding item in `## What`.
+- Every item in `## What` must have a matching item in `## Why` in the same order.
+- Focus on intent and impact rather than implementation details.
+- Keep each bullet concise and clear.
+- Do not include sections such as Summary, Testing, Screenshots, Risks, or Notes unless explicitly requested.
+- Write in professional, developer-friendly English.

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenViewModel.kt
@@ -8,6 +8,7 @@ import com.banko.app.utils.beginningOfCurrentMonth
 import com.banko.app.utils.computeYearEndDate
 import com.banko.app.utils.getLastDayOfMonth
 import kotlinx.coroutines.Job
+import kotlinx.datetime.Clock
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -20,6 +21,8 @@ import kotlinx.coroutines.launch
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 
+private const val SYNC_COOLDOWN_MS = 300_000L
+
 class HomeScreenViewModel(
     private val repository: TransactionRepository
 ) : ViewModel() {
@@ -29,6 +32,7 @@ class HomeScreenViewModel(
     private var transactionsJob: Job? = null
     private var syncJob: Job? = null
     private var lastMonthSelection: YearMonth? = null
+    private val lastSyncTimestamps = mutableMapOf<String, Long>()
 
     init {
         initializeTimespanSelection()
@@ -57,6 +61,7 @@ class HomeScreenViewModel(
             try {
                 val sel = _state.value.selectedTimespan
                 repository.fetchAndStoreTransactionsForDateRange(sel.fromDate, sel.toDate)
+                lastSyncTimestamps["${sel.fromDate}-${sel.toDate}"] = Clock.System.now().toEpochMilliseconds()
                 loadTransactionsForCurrentSelection()
             } catch (_: Exception) {
                 _state.update { it.copy(isRefreshing = false) }
@@ -149,8 +154,15 @@ class HomeScreenViewModel(
 
     private suspend fun performBackgroundSync() {
         val sel = _state.value.selectedTimespan
+        val rangeKey = "${sel.fromDate}-${sel.toDate}"
+        val now = Clock.System.now().toEpochMilliseconds()
+        val lastSync = lastSyncTimestamps[rangeKey]
+
+        if (lastSync != null && now - lastSync < SYNC_COOLDOWN_MS) return
+
         try {
             repository.fetchAndStoreTransactionsForDateRange(sel.fromDate, sel.toDate)
+            lastSyncTimestamps[rangeKey] = Clock.System.now().toEpochMilliseconds()
             val oldestDate = repository.getOldestTransactions()
             val months = generateMonthRange(oldestDate)
             if (months.size > _state.value.availableMonths.size) {


### PR DESCRIPTION
## What
- Add a 5-minute cooldown to background sync so the same date range is not re-fetched repeatedly
- Track last sync timestamp per date range in a map
- Update sync timestamp on user-initiated pull-to-refresh

## Why
- Switching between months unnecessarily re-fetches the same data from the API, wasting bandwidth and slowing the UI
- Per-range tracking ensures different months always sync fresh while preventing duplicate calls for the same range
- Pull-to-refresh resets the timer so users can always force a refresh when they need it