### PR TITLE
Fix side-effect API call at HomeScreen start

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/bottomsheets/ExpenseTagsBottomSheetContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/bottomsheets/ExpenseTagsBottomSheetContent.kt
@@ -18,6 +18,7 @@ import androidx.compose.material3.Text
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
@@ -52,7 +53,9 @@ fun ExpenseTagsBottomSheetContent(
     onClose: () -> Unit
 ) {
 
-    loadNewTags()
+    LaunchedEffect(Unit) {
+        loadNewTags()
+    }
 
     val isNewTag = remember { mutableStateOf(false) }
     val showColorPicker = remember { mutableStateOf(false) }


### PR DESCRIPTION
## What
- Wrap `loadNewTags()` call in a `LaunchedEffect(Unit)` block

## Why
- Prevents the API call from firing on every recomposition of the bottom sheet, which caused redundant network requests on orientation changes, keyboard events, and any other state-driven recomposition