### PR TITLE
HomeScreen, CircularIndicator: cache groupBy and sortCategories with remember

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/CircularIndicator.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/CircularIndicator.kt
@@ -84,9 +84,11 @@ fun CircularIndicator(
     val totalEarnings = transactionsInRange.filter {
         it.expenseTag?.isEarning == true
     }.sumOf { it.amount }.toInt()
-    val categories = when (selectedTimespan) {
-        is TimespanSelection.Month -> sortCategories(transactions, month = Month(selectedTimespan.ym.month))
-        is TimespanSelection.Year -> sortCategories(transactions, year = selectedTimespan.year)
+    val categories = remember(transactions, selectedTimespan) {
+        when (selectedTimespan) {
+            is TimespanSelection.Month -> sortCategories(transactions, month = Month(selectedTimespan.ym.month))
+            is TimespanSelection.Year -> sortCategories(transactions, year = selectedTimespan.year)
+        }
     }
     val totalAmount = categories.sumOf { it.amount.toInt() }.toFloat()
     var animatedEarningsValue by remember { mutableIntStateOf(0) }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreen.kt
@@ -571,7 +571,7 @@ private fun LazyTransactionList(
 ) {
     val listState = rememberLazyListState()
     var openedRowId by remember { mutableStateOf<String?>(null) }
-    val groupedTransactions = transactions.groupBy { it.bookingDate.date }
+    val groupedTransactions = remember(transactions) { transactions.groupBy { it.bookingDate.date } }
 
     LoadingProgressIndicator(isLoading = isLoading)
     PullToRefreshBox(


### PR DESCRIPTION
## What
- Cache groupBy result in LazyTransactionList with remember(transactions)
- Cache sortCategories result in CircularIndicator with remember(transactions, selectedTimespan)

## Why
- groupBy was re-computing the entire transaction grouping map on every recomposition (scroll, state change, etc.), wasting CPU cycles on unchanged data
- sortCategories was re-running the full expense category aggregation on every frame of the spending arc animation (~60 fps for 1000ms), causing unnecessary object allocations and filtering