### PR TITLE
Fix/circular indicator precision

### DIFF
--- a/composeApp/src/androidUnitTest/kotlin/com/banko/app/ui/screens/home/HomeScreenViewModelTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/banko/app/ui/screens/home/HomeScreenViewModelTest.kt
@@ -8,6 +8,8 @@ import io.mockk.mockk
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.launchIn
+import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.TestDispatcher
 import kotlinx.coroutines.test.advanceUntilIdle
@@ -235,5 +237,107 @@ class HomeScreenViewModelTest {
         advanceUntilIdle()
 
         assertNull(vm.state.value.error)
+    }
+
+    @Test
+    fun `timespanState mirrors timespan changes`() = runTest(testDispatcher) {
+        coEvery { repository.getTransactionsForDateRange(any(), any()) } returns flowOf(emptyList())
+
+        val vm = HomeScreenViewModel(repository)
+        advanceUntilIdle()
+
+        val monthSel = TimespanSelection.Month(YearMonth(2024, 6))
+        vm.handleEvent(TransactionsEvent.SelectTimespan(monthSel))
+        advanceUntilIdle()
+
+        assertEquals(monthSel, vm.timespanState.value.selectedTimespan)
+        assertEquals(LocalDateTime(2024, 6, 1, 0, 0), vm.timespanState.value.indicatorDateState)
+        assertEquals(false, vm.timespanState.value.isYearView)
+    }
+
+    @Test
+    fun `uiState mirrors error changes`() = runTest(testDispatcher) {
+        coEvery { repository.getTransactionsForDateRange(any(), any()) } returns flowOf(emptyList())
+        coEvery { repository.deleteTransaction(any()) } throws RuntimeException("Delete failed")
+
+        val vm = HomeScreenViewModel(repository)
+        advanceUntilIdle()
+
+        vm.handleEvent(TransactionsEvent.DeleteTransaction("tx-1"))
+        advanceUntilIdle()
+
+        assertNotNull(vm.uiState.value.error)
+        assertEquals("Delete failed", vm.uiState.value.error)
+    }
+
+    @Test
+    fun `transactionListState mirrors transaction changes`() = runTest(testDispatcher) {
+        val domainTx = DomainTransaction(
+            id = "tx-1",
+            bookingDate = LocalDateTime.parse("2024-01-15T10:30:00"),
+            valueDate = LocalDateTime.parse("2024-01-15T12:00:00"),
+            amount = 42.50,
+            currency = "EUR",
+            debtorAccount = null,
+            remittanceInformationUnstructured = "Test",
+            remittanceInformationUnstructuredArray = emptyList(),
+            bankTransactionCode = "PMNT",
+            internalTransactionId = "int-1",
+            creditorName = null,
+            creditorAccount = null,
+            debtorName = null,
+            remittanceInformationStructuredArray = null,
+            note = null,
+            expenseTag = null
+        )
+        coEvery { repository.getTransactionsForDateRange(any(), any()) } returns flowOf(listOf(domainTx))
+        coEvery { repository.deleteTransaction("tx-1") } returns Unit
+
+        val vm = HomeScreenViewModel(repository)
+        advanceUntilIdle()
+
+        assertEquals(1, vm.transactionListState.value.transactions.size)
+
+        vm.handleEvent(TransactionsEvent.DeleteTransaction("tx-1"))
+        advanceUntilIdle()
+
+        assertTrue(vm.transactionListState.value.transactions.isEmpty())
+    }
+
+    @Test
+    fun `sub-state flows do not emit when unrelated fields change`() = runTest(testDispatcher) {
+        coEvery { repository.getTransactionsForDateRange(any(), any()) } returns flowOf(emptyList())
+
+        val vm = HomeScreenViewModel(repository)
+        advanceUntilIdle()
+
+        val tsEmissions = mutableListOf<TimespanState>()
+
+        val collectJob = vm.timespanState
+            .onEach { tsEmissions.add(it) }
+            .launchIn(this)
+        advanceUntilIdle()
+        tsEmissions.clear()
+
+        vm.handleEvent(TransactionsEvent.DeleteTransaction("tx-1"))
+        advanceUntilIdle()
+
+        collectJob.cancel()
+        advanceUntilIdle()
+
+        assertTrue(tsEmissions.isEmpty(), "timespanState should not emit when deleting a transaction")
+    }
+
+    @Test
+    fun `sub-state initial values match combined state defaults`() = runTest(testDispatcher) {
+        coEvery { repository.getTransactionsForDateRange(any(), any()) } returns flowOf(emptyList())
+
+        val vm = HomeScreenViewModel(repository)
+        advanceUntilIdle()
+
+        val combined = vm.state.value
+        assertEquals(combined.transactions, vm.transactionListState.value.transactions)
+        assertEquals(combined.selectedTimespan, vm.timespanState.value.selectedTimespan)
+        assertEquals(combined.error, vm.uiState.value.error)
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/CircularIndicator.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/CircularIndicator.kt
@@ -90,7 +90,7 @@ fun CircularIndicator(
             is TimespanSelection.Year -> sortCategories(transactions, year = selectedTimespan.year)
         }
     }
-    val totalAmount = categories.sumOf { it.amount.toInt() }.toFloat()
+    val totalAmount = categories.sumOf { it.amount }.toFloat()
     var animatedEarningsValue by remember { mutableIntStateOf(0) }
     var animatedSpendingsValue by remember { mutableIntStateOf(0) }
 
@@ -113,12 +113,22 @@ fun CircularIndicator(
         label = ""
     )
 
-    val animatedSweepAngles = categories.mapIndexed { index, category ->
-        animateFloatAsState(
-            targetValue = (category.amount.toInt() / totalAmount) * 240f,
-            animationSpec = tween(1000),
-            label = ""
-        ).value
+    val animatedSweepAngles = if (totalAmount == 0f) {
+        categories.map { 0f }
+    } else {
+        val rawAngles = categories.map { category ->
+            animateFloatAsState(
+                targetValue = (category.amount.toFloat() / totalAmount) * 240f,
+                animationSpec = tween(1000),
+                label = ""
+            ).value
+        }
+        rawAngles.toMutableList().also { angles ->
+            if (angles.isNotEmpty()) {
+                val sum = angles.sum()
+                angles[angles.lastIndex] += 240f - sum
+            }
+        }
     }
 
     val spendingsLabel = if (isYearView) stringResource(Res.string.yearly_spendings) else stringResource(Res.string.monthly_spendings)

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/CircularIndicator.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/CircularIndicator.kt
@@ -316,7 +316,7 @@ private fun CategoryGrid(categories: List<Category>, itemsPerRow: Int = 5) {
 
 private fun sortCategories(transactions: List<ModelTransaction>, month: kotlinx.datetime.Month): List<Category> {
     val result =
-        transactions.filter { it.expenseTag != null && it.bookingDate.month == month && it.expenseTag.name != "Salary" }
+        transactions.filter { it.expenseTag != null && it.bookingDate.month == month && it.expenseTag.isEarning != true }
     return result.groupBy { it.expenseTag }.map {
         val sum = it.value.sumOf { it.amount }
         val roundedAmount = (sum * 100).roundToLong() / 100.0
@@ -330,7 +330,7 @@ private fun sortCategories(transactions: List<ModelTransaction>, month: kotlinx.
 
 private fun sortCategories(transactions: List<ModelTransaction>, year: Int): List<Category> {
     val result =
-        transactions.filter { it.expenseTag != null && it.bookingDate.year == year && it.expenseTag.name != "Salary" }
+        transactions.filter { it.expenseTag != null && it.bookingDate.year == year && it.expenseTag.isEarning != true }
     return result.groupBy { it.expenseTag }.map {
         val sum = it.value.sumOf { it.amount }
         val roundedAmount = (sum * 100).roundToLong() / 100.0

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/CircularIndicator.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/CircularIndicator.kt
@@ -46,6 +46,7 @@ import com.banko.app.ui.screens.home.TimespanSelection
 import com.banko.app.ui.theme.Grey_Nevada
 import kotlinx.datetime.Month
 import org.jetbrains.compose.resources.stringResource
+import kotlin.math.abs
 import kotlin.math.roundToLong
 
 @Composable
@@ -317,9 +318,10 @@ private fun CategoryGrid(categories: List<Category>, itemsPerRow: Int = 5) {
 private fun sortCategories(transactions: List<ModelTransaction>, month: kotlinx.datetime.Month): List<Category> {
     val result =
         transactions.filter { it.expenseTag != null && it.bookingDate.month == month && it.expenseTag.isEarning != true }
-    return result.groupBy { it.expenseTag }.map {
+    return result.groupBy { it.expenseTag }.mapNotNull {
         val sum = it.value.sumOf { it.amount }
-        val roundedAmount = (sum * 100).roundToLong() / 100.0
+        if (sum >= 0) return@mapNotNull null
+        val roundedAmount = (abs(sum) * 100).roundToLong() / 100.0
         Category(
             name = it.key!!.name,
             amount = roundedAmount,
@@ -331,9 +333,10 @@ private fun sortCategories(transactions: List<ModelTransaction>, month: kotlinx.
 private fun sortCategories(transactions: List<ModelTransaction>, year: Int): List<Category> {
     val result =
         transactions.filter { it.expenseTag != null && it.bookingDate.year == year && it.expenseTag.isEarning != true }
-    return result.groupBy { it.expenseTag }.map {
+    return result.groupBy { it.expenseTag }.mapNotNull {
         val sum = it.value.sumOf { it.amount }
-        val roundedAmount = (sum * 100).roundToLong() / 100.0
+        if (sum >= 0) return@mapNotNull null
+        val roundedAmount = (abs(sum) * 100).roundToLong() / 100.0
         Category(
             name = it.key!!.name,
             amount = roundedAmount,

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreen.kt
@@ -52,7 +52,6 @@ import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
-import androidx.compose.runtime.State
 import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.mutableFloatStateOf
 import androidx.compose.runtime.collectAsState
@@ -98,10 +97,14 @@ import kotlin.math.roundToInt
 @Composable
 fun HomeScreen(component: HomeComponent) {
     val viewModel = koinViewModel<HomeScreenViewModel>()
-    val state = viewModel.state.collectAsState()
+    val transactionListState by viewModel.transactionListState.collectAsState()
+    val timespanState by viewModel.timespanState.collectAsState()
+    val uiState by viewModel.uiState.collectAsState()
 
     HomeScreen(
-        state = state,
+        transactionListState = transactionListState,
+        timespanState = timespanState,
+        uiState = uiState,
         navigateToDetails = component::navigateToDetails,
         onTimespanSelected = { viewModel.handleEvent(TransactionsEvent.SelectTimespan(it)) },
         onRefresh = { viewModel.handleEvent(event = TransactionsEvent.Refresh) },
@@ -114,7 +117,9 @@ fun HomeScreen(component: HomeComponent) {
 
 @Composable
 fun HomeScreen(
-    state: State<HomeScreenState>,
+    transactionListState: TransactionListState,
+    timespanState: TimespanState,
+    uiState: UiState,
     navigateToDetails: (ModelTransaction) -> Unit,
     onTimespanSelected: (TimespanSelection) -> Unit,
     onRefresh: () -> Unit,
@@ -127,8 +132,8 @@ fun HomeScreen(
     var dragOffset by remember { mutableStateOf(0f) }
     val swipeThreshold = 50f
 
-    LaunchedEffect(state.value.error) {
-        state.value.error?.let { error ->
+    LaunchedEffect(uiState.error) {
+        uiState.error?.let { error ->
             snackbarHostState.showSnackbar(error)
             clearError(error)
         }
@@ -140,12 +145,12 @@ fun HomeScreen(
     ) {
         TopContent()
         TimespanBar(
-            selectedTimespan = state.value.selectedTimespan,
-            availableMonths = state.value.availableMonths,
-            availableYears = state.value.availableYears,
-            isYearView = state.value.isYearView,
+            selectedTimespan = timespanState.selectedTimespan,
+            availableMonths = timespanState.availableMonths,
+            availableYears = timespanState.availableYears,
+            isYearView = timespanState.isYearView,
             onTimespanSelected = onTimespanSelected,
-            isLoadingMore = state.value.isLoadingMore,
+            isLoadingMore = transactionListState.isLoadingMore,
             onToggleView = onToggleView,
             onLoadMore = onLoadMore
         )
@@ -154,7 +159,7 @@ fun HomeScreen(
             topContent = {},
             expandedContent = {
                 AnimatedContent(
-                    targetState = state.value.selectedTimespan,
+                    targetState = timespanState.selectedTimespan,
                     transitionSpec = {
                         fun TimespanSelection.weight(): Int = when (this) {
                             is TimespanSelection.Month -> ym.year * 12 + ym.month
@@ -183,20 +188,19 @@ fun HomeScreen(
                                         dragOffset += amount
                                     },
                                     onDragEnd = {
-                                        val current = state.value
-                                        when (val sel = current.selectedTimespan) {
+                                        when (val sel = timespanState.selectedTimespan) {
                                             is TimespanSelection.Month -> {
                                                 when {
                                                     dragOffset < -swipeThreshold -> {
-                                                        val idx = current.availableMonths.indexOf(sel.ym)
-                                                        if (idx < current.availableMonths.size - 1) {
-                                                            onTimespanSelected(TimespanSelection.Month(current.availableMonths[idx + 1]))
+                                                        val idx = timespanState.availableMonths.indexOf(sel.ym)
+                                                        if (idx < timespanState.availableMonths.size - 1) {
+                                                            onTimespanSelected(TimespanSelection.Month(timespanState.availableMonths[idx + 1]))
                                                         }
                                                     }
                                                     dragOffset > swipeThreshold -> {
-                                                        val idx = current.availableMonths.indexOf(sel.ym)
+                                                        val idx = timespanState.availableMonths.indexOf(sel.ym)
                                                         if (idx > 0) {
-                                                            onTimespanSelected(TimespanSelection.Month(current.availableMonths[idx - 1]))
+                                                            onTimespanSelected(TimespanSelection.Month(timespanState.availableMonths[idx - 1]))
                                                         }
                                                     }
                                                 }
@@ -204,15 +208,15 @@ fun HomeScreen(
                                             is TimespanSelection.Year -> {
                                                 when {
                                                     dragOffset < -swipeThreshold -> {
-                                                        val idx = current.availableYears.indexOf(sel.year)
-                                                        if (idx < current.availableYears.size - 1) {
-                                                            onTimespanSelected(TimespanSelection.Year(current.availableYears[idx + 1]))
+                                                        val idx = timespanState.availableYears.indexOf(sel.year)
+                                                        if (idx < timespanState.availableYears.size - 1) {
+                                                            onTimespanSelected(TimespanSelection.Year(timespanState.availableYears[idx + 1]))
                                                         }
                                                     }
                                                     dragOffset > swipeThreshold -> {
-                                                        val idx = current.availableYears.indexOf(sel.year)
+                                                        val idx = timespanState.availableYears.indexOf(sel.year)
                                                         if (idx > 0) {
-                                                            onTimespanSelected(TimespanSelection.Year(current.availableYears[idx - 1]))
+                                                            onTimespanSelected(TimespanSelection.Year(timespanState.availableYears[idx - 1]))
                                                         }
                                                     }
                                                 }
@@ -225,14 +229,14 @@ fun HomeScreen(
                     ) {
                         CircularIndicator(
                             currency = stringResource(Res.string.currency_nok),
-                            transactions = state.value.transactions,
-                            selectedTimespan = state.value.selectedTimespan
+                            transactions = transactionListState.transactions,
+                            selectedTimespan = timespanState.selectedTimespan
                         )
                     }
                 }
             }
         )
-        LoadingProgressIndicator(isLoading = state.value.isLoadingMore)
+        LoadingProgressIndicator(isLoading = transactionListState.isLoadingMore)
         Scaffold(
             snackbarHost = { SnackbarHost(snackbarHostState) }
         ) { padding ->
@@ -243,9 +247,9 @@ fun HomeScreen(
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 LazyTransactionList(
-                    isLoading = state.value.isLoading,
-                    isRefreshing = state.value.isRefreshing,
-                    transactions = state.value.transactions,
+                    isLoading = transactionListState.isLoading,
+                    isRefreshing = transactionListState.isRefreshing,
+                    transactions = transactionListState.transactions,
                     navigateToDetails = navigateToDetails,
                     onRefresh = onRefresh,
                     onDeleteTransaction = onDeleteTransaction

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreen.kt
@@ -58,6 +58,7 @@ import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberUpdatedState
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -131,6 +132,7 @@ fun HomeScreen(
     val snackbarHostState = remember { SnackbarHostState() }
     var dragOffset by remember { mutableStateOf(0f) }
     val swipeThreshold = 50f
+    val currentTimespanState by rememberUpdatedState(timespanState)
 
     LaunchedEffect(uiState.error) {
         uiState.error?.let { error ->
@@ -188,19 +190,20 @@ fun HomeScreen(
                                         dragOffset += amount
                                     },
                                     onDragEnd = {
-                                        when (val sel = timespanState.selectedTimespan) {
+                                        val ts = currentTimespanState
+                                        when (val sel = ts.selectedTimespan) {
                                             is TimespanSelection.Month -> {
                                                 when {
                                                     dragOffset < -swipeThreshold -> {
-                                                        val idx = timespanState.availableMonths.indexOf(sel.ym)
-                                                        if (idx < timespanState.availableMonths.size - 1) {
-                                                            onTimespanSelected(TimespanSelection.Month(timespanState.availableMonths[idx + 1]))
+                                                        val idx = ts.availableMonths.indexOf(sel.ym)
+                                                        if (idx < ts.availableMonths.size - 1) {
+                                                            onTimespanSelected(TimespanSelection.Month(ts.availableMonths[idx + 1]))
                                                         }
                                                     }
                                                     dragOffset > swipeThreshold -> {
-                                                        val idx = timespanState.availableMonths.indexOf(sel.ym)
+                                                        val idx = ts.availableMonths.indexOf(sel.ym)
                                                         if (idx > 0) {
-                                                            onTimespanSelected(TimespanSelection.Month(timespanState.availableMonths[idx - 1]))
+                                                            onTimespanSelected(TimespanSelection.Month(ts.availableMonths[idx - 1]))
                                                         }
                                                     }
                                                 }
@@ -208,15 +211,15 @@ fun HomeScreen(
                                             is TimespanSelection.Year -> {
                                                 when {
                                                     dragOffset < -swipeThreshold -> {
-                                                        val idx = timespanState.availableYears.indexOf(sel.year)
-                                                        if (idx < timespanState.availableYears.size - 1) {
-                                                            onTimespanSelected(TimespanSelection.Year(timespanState.availableYears[idx + 1]))
+                                                        val idx = ts.availableYears.indexOf(sel.year)
+                                                        if (idx < ts.availableYears.size - 1) {
+                                                            onTimespanSelected(TimespanSelection.Year(ts.availableYears[idx + 1]))
                                                         }
                                                     }
                                                     dragOffset > swipeThreshold -> {
-                                                        val idx = timespanState.availableYears.indexOf(sel.year)
+                                                        val idx = ts.availableYears.indexOf(sel.year)
                                                         if (idx > 0) {
-                                                            onTimespanSelected(TimespanSelection.Year(timespanState.availableYears[idx - 1]))
+                                                            onTimespanSelected(TimespanSelection.Year(ts.availableYears[idx - 1]))
                                                         }
                                                     }
                                                 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenState.kt
@@ -24,6 +24,26 @@ sealed class TimespanSelection {
     }
 }
 
+data class TransactionListState(
+    val transactions: List<ModelTransaction> = emptyList(),
+    val isLoading: Boolean = false,
+    val isRefreshing: Boolean = false,
+    val isLoadingMore: Boolean = false,
+)
+
+data class TimespanState(
+    val selectedTimespan: TimespanSelection = TimespanSelection.Month(YearMonth(beginningOfCurrentMonth().year, beginningOfCurrentMonth().monthNumber)),
+    val availableMonths: List<YearMonth> = emptyList(),
+    val availableYears: List<Int> = emptyList(),
+    val isYearView: Boolean = false,
+    val indicatorDateState: LocalDateTime = beginningOfCurrentMonth(),
+)
+
+data class UiState(
+    val error: String? = null,
+    val isSyncing: Boolean = false,
+)
+
 data class HomeScreenState(
     val transactions: List<ModelTransaction> = emptyList(),
     val isLoading: Boolean = false,

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenViewModel.kt
@@ -11,10 +11,12 @@ import kotlinx.coroutines.Job
 import kotlinx.datetime.Clock
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
-import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.flow.launchIn
 import kotlinx.coroutines.flow.onEach
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
@@ -28,6 +30,32 @@ class HomeScreenViewModel(
 ) : ViewModel() {
     private val _state = MutableStateFlow(HomeScreenState())
     val state: StateFlow<HomeScreenState> = _state.asStateFlow()
+
+    val transactionListState: StateFlow<TransactionListState> = _state.map { s ->
+        TransactionListState(
+            transactions = s.transactions,
+            isLoading = s.isLoading,
+            isRefreshing = s.isRefreshing,
+            isLoadingMore = s.isLoadingMore,
+        )
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, TransactionListState())
+
+    val timespanState: StateFlow<TimespanState> = _state.map { s ->
+        TimespanState(
+            selectedTimespan = s.selectedTimespan,
+            availableMonths = s.availableMonths,
+            availableYears = s.availableYears,
+            isYearView = s.isYearView,
+            indicatorDateState = s.indicatorDateState,
+        )
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, TimespanState())
+
+    val uiState: StateFlow<UiState> = _state.map { s ->
+        UiState(
+            error = s.error,
+            isSyncing = s.isSyncing,
+        )
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, UiState())
 
     private var transactionsJob: Job? = null
     private var syncJob: Job? = null
@@ -85,9 +113,7 @@ class HomeScreenViewModel(
                     )
                 }
             } catch (ex: Exception) {
-                _state.update {
-                    it.copy(error = ex.message)
-                }
+                _state.update { it.copy(error = ex.message) }
             }
         }
     }


### PR DESCRIPTION
## What
- Add earnings arc visualization to CircularIndicator
- Earnings arc starts at 240° and ends at 30° (150° sweep)
- Earnings arc uses MediumSeaGreen color and same thickness as spending arc
- Earnings arc is drawn on top of spending arc, overwriting spending categories in the 240°→30° range
- Spending categories now only visible from 150°→240° instead of full 240°

## Why
- Provide visual distinction between spending and earnings categories
- Show earnings as a separate arc segment on the same ring for better visibility
- Improve user understanding of spending vs. earnings breakdown
- Maintain consistent visual weight between spending and earnings indicators
- Simplify the visual representation by removing complex proportional category breakdowns