### PR TITLE
Widget category selection

### DIFF
--- a/composeApp/src/androidUnitTest/kotlin/com/banko/app/ui/screens/home/HomeScreenViewModelTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/banko/app/ui/screens/home/HomeScreenViewModelTest.kt
@@ -351,12 +351,12 @@ class HomeScreenViewModelTest {
 
         vm.handleEvent(TransactionsEvent.SelectTag("tag-1"))
         advanceUntilIdle()
-        assertEquals("tag-1", vm.state.value.selectedTagId)
+        assertEquals(TagFilter.ById("tag-1"), vm.state.value.tagFilter)
 
         vm.handleEvent(TransactionsEvent.SelectTag("tag-1"))
         advanceUntilIdle()
 
-        assertNull(vm.state.value.selectedTagId)
+        assertEquals(TagFilter.None, vm.state.value.tagFilter)
     }
 
     @Test
@@ -372,7 +372,7 @@ class HomeScreenViewModelTest {
         vm.handleEvent(TransactionsEvent.SelectTag("tag-2"))
         advanceUntilIdle()
 
-        assertEquals("tag-2", vm.state.value.selectedTagId)
+        assertEquals(TagFilter.ById("tag-2"), vm.state.value.tagFilter)
     }
 
     @Test
@@ -385,7 +385,7 @@ class HomeScreenViewModelTest {
         vm.handleEvent(TransactionsEvent.SelectTag(null))
         advanceUntilIdle()
 
-        assertEquals("uncategorized", vm.state.value.selectedTagId)
+        assertEquals(TagFilter.Uncategorized, vm.state.value.tagFilter)
     }
 
     @Test
@@ -397,16 +397,16 @@ class HomeScreenViewModelTest {
 
         vm.handleEvent(TransactionsEvent.SelectTag(null))
         advanceUntilIdle()
-        assertEquals("uncategorized", vm.state.value.selectedTagId)
+        assertEquals(TagFilter.Uncategorized, vm.state.value.tagFilter)
 
         vm.handleEvent(TransactionsEvent.SelectTag(null))
         advanceUntilIdle()
 
-        assertNull(vm.state.value.selectedTagId)
+        assertEquals(TagFilter.None, vm.state.value.tagFilter)
     }
 
     @Test
-    fun `changing month timespan resets selectedTagId`() = runTest(testDispatcher) {
+    fun `changing month timespan resets tagFilter`() = runTest(testDispatcher) {
         coEvery { repository.getTransactionsForDateRange(any(), any()) } returns flowOf(emptyList())
 
         val vm = HomeScreenViewModel(repository)
@@ -414,16 +414,16 @@ class HomeScreenViewModelTest {
 
         vm.handleEvent(TransactionsEvent.SelectTag("tag-1"))
         advanceUntilIdle()
-        assertEquals("tag-1", vm.state.value.selectedTagId)
+        assertEquals(TagFilter.ById("tag-1"), vm.state.value.tagFilter)
 
         vm.handleEvent(TransactionsEvent.SelectTimespan(TimespanSelection.Month(YearMonth(2024, 6))))
         advanceUntilIdle()
 
-        assertNull(vm.state.value.selectedTagId)
+        assertEquals(TagFilter.None, vm.state.value.tagFilter)
     }
 
     @Test
-    fun `changing year timespan resets selectedTagId`() = runTest(testDispatcher) {
+    fun `changing year timespan resets tagFilter`() = runTest(testDispatcher) {
         coEvery { repository.getTransactionsForDateRange(any(), any()) } returns flowOf(emptyList())
 
         val vm = HomeScreenViewModel(repository)
@@ -431,12 +431,12 @@ class HomeScreenViewModelTest {
 
         vm.handleEvent(TransactionsEvent.SelectTag("tag-1"))
         advanceUntilIdle()
-        assertEquals("tag-1", vm.state.value.selectedTagId)
+        assertEquals(TagFilter.ById("tag-1"), vm.state.value.tagFilter)
 
         vm.handleEvent(TransactionsEvent.SelectTimespan(TimespanSelection.Year(2025)))
         advanceUntilIdle()
 
-        assertNull(vm.state.value.selectedTagId)
+        assertEquals(TagFilter.None, vm.state.value.tagFilter)
     }
 
     @Test

--- a/composeApp/src/androidUnitTest/kotlin/com/banko/app/ui/screens/home/HomeScreenViewModelTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/banko/app/ui/screens/home/HomeScreenViewModelTest.kt
@@ -1,5 +1,6 @@
 package com.banko.app.ui.screens.home
 
+import com.banko.app.domain.model.ExpenseTag as DomainExpenseTag
 import com.banko.app.domain.model.Transaction as DomainTransaction
 import com.banko.app.data.repository.TransactionRepository
 import io.mockk.coEvery
@@ -339,5 +340,200 @@ class HomeScreenViewModelTest {
         assertEquals(combined.transactions, vm.transactionListState.value.transactions)
         assertEquals(combined.selectedTimespan, vm.timespanState.value.selectedTimespan)
         assertEquals(combined.error, vm.uiState.value.error)
+    }
+
+    @Test
+    fun `SelectTag with same tag deselects`() = runTest(testDispatcher) {
+        coEvery { repository.getTransactionsForDateRange(any(), any()) } returns flowOf(emptyList())
+
+        val vm = HomeScreenViewModel(repository)
+        advanceUntilIdle()
+
+        vm.handleEvent(TransactionsEvent.SelectTag("tag-1"))
+        advanceUntilIdle()
+        assertEquals("tag-1", vm.state.value.selectedTagId)
+
+        vm.handleEvent(TransactionsEvent.SelectTag("tag-1"))
+        advanceUntilIdle()
+
+        assertNull(vm.state.value.selectedTagId)
+    }
+
+    @Test
+    fun `SelectTag with different tag replaces selection`() = runTest(testDispatcher) {
+        coEvery { repository.getTransactionsForDateRange(any(), any()) } returns flowOf(emptyList())
+
+        val vm = HomeScreenViewModel(repository)
+        advanceUntilIdle()
+
+        vm.handleEvent(TransactionsEvent.SelectTag("tag-1"))
+        advanceUntilIdle()
+
+        vm.handleEvent(TransactionsEvent.SelectTag("tag-2"))
+        advanceUntilIdle()
+
+        assertEquals("tag-2", vm.state.value.selectedTagId)
+    }
+
+    @Test
+    fun `SelectTag with null selects uncategorized`() = runTest(testDispatcher) {
+        coEvery { repository.getTransactionsForDateRange(any(), any()) } returns flowOf(emptyList())
+
+        val vm = HomeScreenViewModel(repository)
+        advanceUntilIdle()
+
+        vm.handleEvent(TransactionsEvent.SelectTag(null))
+        advanceUntilIdle()
+
+        assertEquals("uncategorized", vm.state.value.selectedTagId)
+    }
+
+    @Test
+    fun `toggle null tag deselects uncategorized`() = runTest(testDispatcher) {
+        coEvery { repository.getTransactionsForDateRange(any(), any()) } returns flowOf(emptyList())
+
+        val vm = HomeScreenViewModel(repository)
+        advanceUntilIdle()
+
+        vm.handleEvent(TransactionsEvent.SelectTag(null))
+        advanceUntilIdle()
+        assertEquals("uncategorized", vm.state.value.selectedTagId)
+
+        vm.handleEvent(TransactionsEvent.SelectTag(null))
+        advanceUntilIdle()
+
+        assertNull(vm.state.value.selectedTagId)
+    }
+
+    @Test
+    fun `changing month timespan resets selectedTagId`() = runTest(testDispatcher) {
+        coEvery { repository.getTransactionsForDateRange(any(), any()) } returns flowOf(emptyList())
+
+        val vm = HomeScreenViewModel(repository)
+        advanceUntilIdle()
+
+        vm.handleEvent(TransactionsEvent.SelectTag("tag-1"))
+        advanceUntilIdle()
+        assertEquals("tag-1", vm.state.value.selectedTagId)
+
+        vm.handleEvent(TransactionsEvent.SelectTimespan(TimespanSelection.Month(YearMonth(2024, 6))))
+        advanceUntilIdle()
+
+        assertNull(vm.state.value.selectedTagId)
+    }
+
+    @Test
+    fun `changing year timespan resets selectedTagId`() = runTest(testDispatcher) {
+        coEvery { repository.getTransactionsForDateRange(any(), any()) } returns flowOf(emptyList())
+
+        val vm = HomeScreenViewModel(repository)
+        advanceUntilIdle()
+
+        vm.handleEvent(TransactionsEvent.SelectTag("tag-1"))
+        advanceUntilIdle()
+        assertEquals("tag-1", vm.state.value.selectedTagId)
+
+        vm.handleEvent(TransactionsEvent.SelectTimespan(TimespanSelection.Year(2025)))
+        advanceUntilIdle()
+
+        assertNull(vm.state.value.selectedTagId)
+    }
+
+    @Test
+    fun `filteredTransactionListState shows all when no tag selected`() = runTest(testDispatcher) {
+        val tag1 = DomainExpenseTag(id = "tag-1", name = "Food", color = 0xFF0000FF, isEarning = false, aka = emptyList())
+        val txWithTag = DomainTransaction(
+            id = "tx-1", bookingDate = LocalDateTime.parse("2024-01-15T10:30:00"),
+            valueDate = LocalDateTime.parse("2024-01-15T12:00:00"), amount = 50.0, currency = "EUR",
+            debtorAccount = null, remittanceInformationUnstructured = "Groceries",
+            remittanceInformationUnstructuredArray = emptyList(), bankTransactionCode = "PMNT",
+            internalTransactionId = "int-1", creditorName = null, creditorAccount = null,
+            debtorName = null, remittanceInformationStructuredArray = null, note = null,
+            expenseTag = tag1
+        )
+        val txNoTag = DomainTransaction(
+            id = "tx-2", bookingDate = LocalDateTime.parse("2024-01-16T10:30:00"),
+            valueDate = LocalDateTime.parse("2024-01-16T12:00:00"), amount = 30.0, currency = "EUR",
+            debtorAccount = null, remittanceInformationUnstructured = "Other",
+            remittanceInformationUnstructuredArray = emptyList(), bankTransactionCode = "PMNT",
+            internalTransactionId = "int-2", creditorName = null, creditorAccount = null,
+            debtorName = null, remittanceInformationStructuredArray = null, note = null,
+            expenseTag = null
+        )
+        coEvery { repository.getTransactionsForDateRange(any(), any()) } returns flowOf(listOf(txWithTag, txNoTag))
+
+        val vm = HomeScreenViewModel(repository)
+        advanceUntilIdle()
+
+        assertEquals(2, vm.filteredTransactionListState.value.transactions.size)
+    }
+
+    @Test
+    fun `filteredTransactionListState filters by tag id`() = runTest(testDispatcher) {
+        val tag1 = DomainExpenseTag(id = "tag-1", name = "Food", color = 0xFF0000FF, isEarning = false, aka = emptyList())
+        val tag2 = DomainExpenseTag(id = "tag-2", name = "Transport", color = 0xFF00FF00, isEarning = false, aka = emptyList())
+        val txTag1 = DomainTransaction(
+            id = "tx-1", bookingDate = LocalDateTime.parse("2024-01-15T10:30:00"),
+            valueDate = LocalDateTime.parse("2024-01-15T12:00:00"), amount = 50.0, currency = "EUR",
+            debtorAccount = null, remittanceInformationUnstructured = "Groceries",
+            remittanceInformationUnstructuredArray = emptyList(), bankTransactionCode = "PMNT",
+            internalTransactionId = "int-1", creditorName = null, creditorAccount = null,
+            debtorName = null, remittanceInformationStructuredArray = null, note = null,
+            expenseTag = tag1
+        )
+        val txTag2 = DomainTransaction(
+            id = "tx-2", bookingDate = LocalDateTime.parse("2024-01-16T10:30:00"),
+            valueDate = LocalDateTime.parse("2024-01-16T12:00:00"), amount = 30.0, currency = "EUR",
+            debtorAccount = null, remittanceInformationUnstructured = "Bus",
+            remittanceInformationUnstructuredArray = emptyList(), bankTransactionCode = "PMNT",
+            internalTransactionId = "int-2", creditorName = null, creditorAccount = null,
+            debtorName = null, remittanceInformationStructuredArray = null, note = null,
+            expenseTag = tag2
+        )
+        coEvery { repository.getTransactionsForDateRange(any(), any()) } returns flowOf(listOf(txTag1, txTag2))
+
+        val vm = HomeScreenViewModel(repository)
+        advanceUntilIdle()
+
+        vm.handleEvent(TransactionsEvent.SelectTag("tag-1"))
+        advanceUntilIdle()
+
+        val filtered = vm.filteredTransactionListState.value
+        assertEquals(1, filtered.transactions.size)
+        assertEquals("tx-1", filtered.transactions.first().id)
+    }
+
+    @Test
+    fun `filteredTransactionListState filters by uncategorized`() = runTest(testDispatcher) {
+        val tag1 = DomainExpenseTag(id = "tag-1", name = "Food", color = 0xFF0000FF, isEarning = false, aka = emptyList())
+        val txWithTag = DomainTransaction(
+            id = "tx-1", bookingDate = LocalDateTime.parse("2024-01-15T10:30:00"),
+            valueDate = LocalDateTime.parse("2024-01-15T12:00:00"), amount = 50.0, currency = "EUR",
+            debtorAccount = null, remittanceInformationUnstructured = "Groceries",
+            remittanceInformationUnstructuredArray = emptyList(), bankTransactionCode = "PMNT",
+            internalTransactionId = "int-1", creditorName = null, creditorAccount = null,
+            debtorName = null, remittanceInformationStructuredArray = null, note = null,
+            expenseTag = tag1
+        )
+        val txNoTag = DomainTransaction(
+            id = "tx-2", bookingDate = LocalDateTime.parse("2024-01-16T10:30:00"),
+            valueDate = LocalDateTime.parse("2024-01-16T12:00:00"), amount = 30.0, currency = "EUR",
+            debtorAccount = null, remittanceInformationUnstructured = "Other",
+            remittanceInformationUnstructuredArray = emptyList(), bankTransactionCode = "PMNT",
+            internalTransactionId = "int-2", creditorName = null, creditorAccount = null,
+            debtorName = null, remittanceInformationStructuredArray = null, note = null,
+            expenseTag = null
+        )
+        coEvery { repository.getTransactionsForDateRange(any(), any()) } returns flowOf(listOf(txWithTag, txNoTag))
+
+        val vm = HomeScreenViewModel(repository)
+        advanceUntilIdle()
+
+        vm.handleEvent(TransactionsEvent.SelectTag(null))
+        advanceUntilIdle()
+
+        val filtered = vm.filteredTransactionListState.value
+        assertEquals(1, filtered.transactions.size)
+        assertEquals("tx-2", filtered.transactions.first().id)
     }
 }

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -49,6 +49,7 @@
     <string name="expense_tag_no_tag">- No tag added</string>
     <string name="expense_tag_update_earning">Earning</string>
     <string name="expense_tag_update_expense">Expense</string>
+    <string name="expense_tag_uncategorized">uncategorized</string>
     <string name="expense_tags">Expense Tags</string>
     <string name="expense_tags_bottom_sheet_button_close">Close</string>
     <string name="expense_tags_title">EXPENSE TAGS</string>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -47,6 +47,7 @@
     <string name="expense_tag_delete_title">Delete Tag</string>
     <string name="expense_tag_delete_yes">Yes</string>
     <string name="expense_tag_no_tag">- No tag added</string>
+    <string name="expense_tag_Other">Other</string>
     <string name="expense_tag_update_earning">Earning</string>
     <string name="expense_tag_update_expense">Expense</string>
     <string name="expense_tag_uncategorized">uncategorized</string>

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/CircularIndicator.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/CircularIndicator.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import banko.composeapp.generated.resources.Res
+import banko.composeapp.generated.resources.expense_tag_Other
 import banko.composeapp.generated.resources.expense_tag_uncategorized
 import banko.composeapp.generated.resources.monthly_earnings
 import banko.composeapp.generated.resources.monthly_spendings
@@ -67,6 +68,7 @@ fun CircularIndicator(
     smallTextFontSize: TextUnit = MaterialTheme.typography.bodyMedium.fontSize,
     onCategoryClick: ((String?) -> Unit)? = null,
     selectedCategoryId: String? = null,
+    isUncategorizedSelected: Boolean = false,
 ) {
     val (transactionsInRange, isYearView) = when (selectedTimespan) {
         is TimespanSelection.Month -> {
@@ -92,10 +94,11 @@ fun CircularIndicator(
     val totalEarnings = transactionsInRange.filter {
         it.expenseTag?.isEarning == true
     }.sumOf { it.amount }.toInt()
+    val otherLabel = stringResource(Res.string.expense_tag_Other)
     val categories = remember(transactions, selectedTimespan) {
         when (selectedTimespan) {
-            is TimespanSelection.Month -> sortCategories(transactions, month = Month(selectedTimespan.ym.month))
-            is TimespanSelection.Year -> sortCategories(transactions, year = selectedTimespan.year)
+            is TimespanSelection.Month -> sortCategories(transactions, month = Month(selectedTimespan.ym.month), otherLabel = otherLabel)
+            is TimespanSelection.Year -> sortCategories(transactions, year = selectedTimespan.year, otherLabel = otherLabel)
         }
     }
     val totalAmount = categories.sumOf { it.amount }.toFloat()
@@ -187,6 +190,7 @@ fun CircularIndicator(
             categories = categories,
             onCategoryClick = onCategoryClick,
             selectedCategoryId = selectedCategoryId,
+            isUncategorizedSelected = isUncategorizedSelected,
         )
     }
 }
@@ -325,6 +329,7 @@ private fun CategoryGrid(
     itemsPerRow: Int = 5,
     onCategoryClick: ((String?) -> Unit)? = null,
     selectedCategoryId: String? = null,
+    isUncategorizedSelected: Boolean = false,
 ) {
     Column(
         modifier = Modifier
@@ -340,11 +345,8 @@ private fun CategoryGrid(
             ) {
                 rowCategories.forEach { category ->
                     val isOther = category.id == null
-                    val isSelected = if (isOther) {
-                        selectedCategoryId == stringResource(Res.string.expense_tag_uncategorized)
-                    } else {
-                        category.id == selectedCategoryId
-                    }
+                    val isSelected = if (isOther) isUncategorizedSelected
+                    else category.id == selectedCategoryId
                     Column(
                         horizontalAlignment = Alignment.CenterHorizontally,
                         modifier = Modifier
@@ -395,7 +397,7 @@ private fun CategoryGrid(
     }
 }
 
-private fun sortCategories(transactions: List<ModelTransaction>, month: kotlinx.datetime.Month): List<Category> {
+private fun sortCategories(transactions: List<ModelTransaction>, month: kotlinx.datetime.Month, otherLabel: String): List<Category> {
     val result =
         transactions.filter { it.bookingDate.month == month && it.expenseTag?.isEarning != true }
     return result.groupBy { it.expenseTag }.mapNotNull {
@@ -413,7 +415,7 @@ private fun sortCategories(transactions: List<ModelTransaction>, month: kotlinx.
         } else {
             Category(
                 id = null,
-                name = "Other",
+                name = otherLabel,
                 amount = roundedAmount,
                 color = Color.Gray
             )
@@ -421,7 +423,7 @@ private fun sortCategories(transactions: List<ModelTransaction>, month: kotlinx.
     }
 }
 
-private fun sortCategories(transactions: List<ModelTransaction>, year: Int): List<Category> {
+private fun sortCategories(transactions: List<ModelTransaction>, year: Int, otherLabel: String): List<Category> {
     val result =
         transactions.filter { it.bookingDate.year == year && it.expenseTag?.isEarning != true }
     return result.groupBy { it.expenseTag }.mapNotNull {
@@ -439,7 +441,7 @@ private fun sortCategories(transactions: List<ModelTransaction>, year: Int): Lis
         } else {
             Category(
                 id = null,
-                name = "Other",
+                name = otherLabel,
                 amount = roundedAmount,
                 color = Color.Gray
             )

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/CircularIndicator.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/CircularIndicator.kt
@@ -4,6 +4,8 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.animateIntAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
@@ -22,6 +24,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.geometry.Size
@@ -60,6 +63,8 @@ fun CircularIndicator(
     indicatorStroke: Float = 60f,
     smallTextColor: Color = MaterialTheme.colorScheme.primary.copy(alpha = 0.5f),
     smallTextFontSize: TextUnit = MaterialTheme.typography.bodyMedium.fontSize,
+    onCategoryClick: ((String) -> Unit)? = null,
+    selectedCategoryId: String? = null,
 ) {
     val (transactionsInRange, isYearView) = when (selectedTimespan) {
         is TimespanSelection.Month -> {
@@ -172,7 +177,11 @@ fun CircularIndicator(
                 smallTextFontSize = smallTextFontSize,
             )
         }
-        CategoryGrid(categories = categories)
+        CategoryGrid(
+            categories = categories,
+            onCategoryClick = onCategoryClick,
+            selectedCategoryId = selectedCategoryId,
+        )
     }
 }
 
@@ -271,7 +280,12 @@ private fun EmbeddedElements(
 }
 
 @Composable
-private fun CategoryGrid(categories: List<Category>, itemsPerRow: Int = 5) {
+private fun CategoryGrid(
+    categories: List<Category>,
+    itemsPerRow: Int = 5,
+    onCategoryClick: ((String) -> Unit)? = null,
+    selectedCategoryId: String? = null,
+) {
     Column(
         modifier = Modifier
             .fillMaxWidth().offset(y = (-30).dp),
@@ -285,9 +299,17 @@ private fun CategoryGrid(categories: List<Category>, itemsPerRow: Int = 5) {
                 horizontalArrangement = Arrangement.SpaceEvenly
             ) {
                 rowCategories.forEach { category ->
+                    val isSelected = category.id == selectedCategoryId
                     Column(
                         horizontalAlignment = Alignment.CenterHorizontally,
-                        modifier = Modifier.padding(horizontal = 8.dp)
+                        modifier = Modifier
+                            .clip(RoundedCornerShape(8.dp))
+                            .then(
+                                if (isSelected) Modifier.background(MaterialTheme.colorScheme.primary.copy(alpha = 0.15f))
+                                else Modifier
+                            )
+                            .clickable { onCategoryClick?.invoke(category.id) }
+                            .padding(horizontal = 8.dp, vertical = 4.dp)
                     ) {
                         Box(
                             modifier = Modifier
@@ -323,6 +345,7 @@ private fun sortCategories(transactions: List<ModelTransaction>, month: kotlinx.
         if (sum >= 0) return@mapNotNull null
         val roundedAmount = (abs(sum) * 100).roundToLong() / 100.0
         Category(
+            id = it.key!!.id,
             name = it.key!!.name,
             amount = roundedAmount,
             color = it.key!!.color
@@ -338,6 +361,7 @@ private fun sortCategories(transactions: List<ModelTransaction>, year: Int): Lis
         if (sum >= 0) return@mapNotNull null
         val roundedAmount = (abs(sum) * 100).roundToLong() / 100.0
         Category(
+            id = it.key!!.id,
             name = it.key!!.name,
             amount = roundedAmount,
             color = it.key!!.color

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/CircularIndicator.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/CircularIndicator.kt
@@ -64,7 +64,7 @@ fun CircularIndicator(
     indicatorStroke: Float = 60f,
     smallTextColor: Color = MaterialTheme.colorScheme.primary.copy(alpha = 0.5f),
     smallTextFontSize: TextUnit = MaterialTheme.typography.bodyMedium.fontSize,
-    onCategoryClick: ((String) -> Unit)? = null,
+    onCategoryClick: ((String?) -> Unit)? = null,
     selectedCategoryId: String? = null,
 ) {
     val (transactionsInRange, isYearView) = when (selectedTimespan) {
@@ -201,7 +201,7 @@ fun DrawScope.foregroundIndicator(
 ) {
     var currentStartAngle = startAngle
     categories.forEachIndexed { index, category ->
-        val isOther = category.id == "uncategorized"
+        val isOther = category.id == null
         val arcTopLeft = Offset(
             (size.width - componentSize.width) / 2f,
             (size.height - componentSize.height) / 2f
@@ -322,7 +322,7 @@ private fun EmbeddedElements(
 private fun CategoryGrid(
     categories: List<Category>,
     itemsPerRow: Int = 5,
-    onCategoryClick: ((String) -> Unit)? = null,
+    onCategoryClick: ((String?) -> Unit)? = null,
     selectedCategoryId: String? = null,
 ) {
     Column(
@@ -339,7 +339,7 @@ private fun CategoryGrid(
             ) {
                 rowCategories.forEach { category ->
                     val isSelected = category.id == selectedCategoryId
-                    val isOther = category.id == "uncategorized"
+                    val isOther = category.id == null
                     Column(
                         horizontalAlignment = Alignment.CenterHorizontally,
                         modifier = Modifier
@@ -411,7 +411,7 @@ private fun sortCategories(transactions: List<ModelTransaction>, month: kotlinx.
             )
         } else {
             Category(
-                id = "uncategorized",
+                id = null,
                 name = "Other",
                 amount = roundedAmount,
                 color = Color.Gray
@@ -437,7 +437,7 @@ private fun sortCategories(transactions: List<ModelTransaction>, year: Int): Lis
             )
         } else {
             Category(
-                id = "uncategorized",
+                id = null,
                 name = "Other",
                 amount = roundedAmount,
                 color = Color.Gray

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/CircularIndicator.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/CircularIndicator.kt
@@ -4,6 +4,7 @@ import androidx.compose.animation.core.animateFloatAsState
 import androidx.compose.animation.core.animateIntAsState
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.background
+import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.foundation.layout.Arrangement
@@ -139,6 +140,8 @@ fun CircularIndicator(
 
     val spendingsLabel = if (isYearView) stringResource(Res.string.yearly_spendings) else stringResource(Res.string.monthly_spendings)
     val earningsLabel = if (isYearView) stringResource(Res.string.yearly_earnings) else stringResource(Res.string.monthly_earnings)
+    val primaryColor = MaterialTheme.colorScheme.primary
+    val surfaceColor = MaterialTheme.colorScheme.surface.copy(alpha = 0.8f)
 
     Column(
         verticalArrangement = Arrangement.Center,
@@ -160,6 +163,8 @@ fun CircularIndicator(
                         startAngle = 150f,
                         componentSize = componentSize,
                         indicatorStroke = indicatorStroke,
+                        primaryColor = primaryColor,
+                        surfaceColor = surfaceColor,
                     )
                 },
             verticalArrangement = Arrangement.Center,
@@ -191,24 +196,58 @@ fun DrawScope.foregroundIndicator(
     componentSize: Size,
     indicatorStroke: Float,
     startAngle: Float,
+    primaryColor: Color,
+    surfaceColor: Color,
 ) {
     var currentStartAngle = startAngle
     categories.forEachIndexed { index, category ->
-        drawArc(
-            size = componentSize,
-            color = category.color,
-            startAngle = currentStartAngle,
-            sweepAngle = animatedSweepAngles[index],
-            useCenter = false,
-            style = Stroke(
-                width = indicatorStroke,
-                cap = StrokeCap.Square
-            ),
-            topLeft = Offset(
-                (size.width - componentSize.width) / 2f,
-                (size.height - componentSize.height) / 2f
-            )
+        val isOther = category.id == "uncategorized"
+        val arcTopLeft = Offset(
+            (size.width - componentSize.width) / 2f,
+            (size.height - componentSize.height) / 2f
         )
+
+        if (isOther) {
+            drawArc(
+                color = surfaceColor,
+                startAngle = currentStartAngle,
+                sweepAngle = animatedSweepAngles[index],
+                useCenter = false,
+                size = componentSize,
+                style = Stroke(
+                    width = indicatorStroke,
+                    cap = StrokeCap.Square
+                ),
+                topLeft = arcTopLeft
+            )
+
+            drawArc(
+                color = primaryColor,
+                startAngle = currentStartAngle,
+                sweepAngle = animatedSweepAngles[index],
+                useCenter = false,
+                size = componentSize,
+                style = Stroke(
+                    width = indicatorStroke * 0.15f,
+                    cap = StrokeCap.Square
+                ),
+                topLeft = arcTopLeft
+            )
+        } else {
+            drawArc(
+                size = componentSize,
+                color = category.color,
+                startAngle = currentStartAngle,
+                sweepAngle = animatedSweepAngles[index],
+                useCenter = false,
+                style = Stroke(
+                    width = indicatorStroke,
+                    cap = StrokeCap.Square
+                ),
+                topLeft = arcTopLeft
+            )
+        }
+
         currentStartAngle += animatedSweepAngles[index]
     }
 }
@@ -300,25 +339,43 @@ private fun CategoryGrid(
             ) {
                 rowCategories.forEach { category ->
                     val isSelected = category.id == selectedCategoryId
+                    val isOther = category.id == "uncategorized"
                     Column(
                         horizontalAlignment = Alignment.CenterHorizontally,
                         modifier = Modifier
                             .clip(RoundedCornerShape(8.dp))
                             .then(
-                                if (isSelected) Modifier.background(MaterialTheme.colorScheme.primary.copy(alpha = 0.15f))
-                                else Modifier
+                                if (isSelected) {
+                                    val bgColor = if (isOther)
+                                        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.15f)
+                                    else
+                                        MaterialTheme.colorScheme.primary.copy(alpha = 0.15f)
+                                    Modifier.background(bgColor)
+                                } else Modifier
                             )
                             .clickable { onCategoryClick?.invoke(category.id) }
                             .padding(horizontal = 8.dp, vertical = 4.dp)
                     ) {
-                        Box(
-                            modifier = Modifier
-                                .size(12.dp)
-                                .background(
-                                    color = category.color,
-                                    shape = MaterialTheme.shapes.small
-                                )
-                        )
+                        if (isOther) {
+                            Box(
+                                modifier = Modifier
+                                    .size(12.dp)
+                                    .border(
+                                        width = 1.dp,
+                                        color = MaterialTheme.colorScheme.primary,
+                                        shape = MaterialTheme.shapes.small
+                                    )
+                            )
+                        } else {
+                            Box(
+                                modifier = Modifier
+                                    .size(12.dp)
+                                    .background(
+                                        color = category.color,
+                                        shape = MaterialTheme.shapes.small
+                                    )
+                            )
+                        }
                         Text(
                             modifier = Modifier.padding(top = 4.dp),
                             text = category.amount.toString(),
@@ -339,32 +396,52 @@ private fun CategoryGrid(
 
 private fun sortCategories(transactions: List<ModelTransaction>, month: kotlinx.datetime.Month): List<Category> {
     val result =
-        transactions.filter { it.expenseTag != null && it.bookingDate.month == month && it.expenseTag.isEarning != true }
+        transactions.filter { it.bookingDate.month == month && it.expenseTag?.isEarning != true }
     return result.groupBy { it.expenseTag }.mapNotNull {
         val sum = it.value.sumOf { it.amount }
         if (sum >= 0) return@mapNotNull null
         val roundedAmount = (abs(sum) * 100).roundToLong() / 100.0
-        Category(
-            id = it.key!!.id,
-            name = it.key!!.name,
-            amount = roundedAmount,
-            color = it.key!!.color
-        )
+        val tag = it.key
+        if (tag != null) {
+            Category(
+                id = tag.id,
+                name = tag.name,
+                amount = roundedAmount,
+                color = tag.color
+            )
+        } else {
+            Category(
+                id = "uncategorized",
+                name = "Other",
+                amount = roundedAmount,
+                color = Color.Gray
+            )
+        }
     }
 }
 
 private fun sortCategories(transactions: List<ModelTransaction>, year: Int): List<Category> {
     val result =
-        transactions.filter { it.expenseTag != null && it.bookingDate.year == year && it.expenseTag.isEarning != true }
+        transactions.filter { it.bookingDate.year == year && it.expenseTag?.isEarning != true }
     return result.groupBy { it.expenseTag }.mapNotNull {
         val sum = it.value.sumOf { it.amount }
         if (sum >= 0) return@mapNotNull null
         val roundedAmount = (abs(sum) * 100).roundToLong() / 100.0
-        Category(
-            id = it.key!!.id,
-            name = it.key!!.name,
-            amount = roundedAmount,
-            color = it.key!!.color
-        )
+        val tag = it.key
+        if (tag != null) {
+            Category(
+                id = tag.id,
+                name = tag.name,
+                amount = roundedAmount,
+                color = tag.color
+            )
+        } else {
+            Category(
+                id = "uncategorized",
+                name = "Other",
+                amount = roundedAmount,
+                color = Color.Gray
+            )
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/CircularIndicator.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/CircularIndicator.kt
@@ -39,6 +39,7 @@ import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import banko.composeapp.generated.resources.Res
+import banko.composeapp.generated.resources.expense_tag_uncategorized
 import banko.composeapp.generated.resources.monthly_earnings
 import banko.composeapp.generated.resources.monthly_spendings
 import banko.composeapp.generated.resources.yearly_earnings
@@ -338,19 +339,19 @@ private fun CategoryGrid(
                 horizontalArrangement = Arrangement.SpaceEvenly
             ) {
                 rowCategories.forEach { category ->
-                    val isSelected = category.id == selectedCategoryId
                     val isOther = category.id == null
+                    val isSelected = if (isOther) {
+                        selectedCategoryId == stringResource(Res.string.expense_tag_uncategorized)
+                    } else {
+                        category.id == selectedCategoryId
+                    }
                     Column(
                         horizontalAlignment = Alignment.CenterHorizontally,
                         modifier = Modifier
                             .clip(RoundedCornerShape(8.dp))
                             .then(
                                 if (isSelected) {
-                                    val bgColor = if (isOther)
-                                        MaterialTheme.colorScheme.onSurface.copy(alpha = 0.15f)
-                                    else
-                                        MaterialTheme.colorScheme.primary.copy(alpha = 0.15f)
-                                    Modifier.background(bgColor)
+                                    Modifier.background(MaterialTheme.colorScheme.primary.copy(alpha = 0.15f))
                                 } else Modifier
                             )
                             .clickable { onCategoryClick?.invoke(category.id) }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/models/Category.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/models/Category.kt
@@ -13,6 +13,7 @@ import com.banko.app.ui.theme.SteelBlue
 import com.banko.app.ui.theme.Teal
 
 data class Category(
+    val id: String,
     val name: String,
     val amount: Double,
     val color: Color

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/models/Category.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/models/Category.kt
@@ -13,7 +13,7 @@ import com.banko.app.ui.theme.SteelBlue
 import com.banko.app.ui.theme.Teal
 
 data class Category(
-    val id: String,
+    val id: String?,
     val name: String,
     val amount: Double,
     val color: Color

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreen.kt
@@ -135,7 +135,7 @@ fun HomeScreen(
     onDeleteTransaction: (String) -> Unit,
     onToggleView: () -> Unit,
     onLoadMore: () -> Unit,
-    onCategoryClick: (String) -> Unit,
+    onCategoryClick: (String?) -> Unit,
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
     var dragOffset by remember { mutableStateOf(0f) }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreen.kt
@@ -102,7 +102,8 @@ fun HomeScreen(component: HomeComponent) {
     val filteredTransactionListState by viewModel.filteredTransactionListState.collectAsState()
     val timespanState by viewModel.timespanState.collectAsState()
     val uiState by viewModel.uiState.collectAsState()
-    val selectedCategoryId by viewModel.selectedTagId.collectAsState()
+    val selectedCategoryId by viewModel.selectedCategoryId.collectAsState()
+    val isUncategorizedSelected by viewModel.isUncategorizedSelected.collectAsState()
 
     HomeScreen(
         transactionListState = transactionListState,
@@ -110,6 +111,7 @@ fun HomeScreen(component: HomeComponent) {
         timespanState = timespanState,
         uiState = uiState,
         selectedCategoryId = selectedCategoryId,
+        isUncategorizedSelected = isUncategorizedSelected,
         navigateToDetails = component::navigateToDetails,
         onTimespanSelected = { viewModel.handleEvent(TransactionsEvent.SelectTimespan(it)) },
         onRefresh = { viewModel.handleEvent(event = TransactionsEvent.Refresh) },
@@ -128,6 +130,7 @@ fun HomeScreen(
     timespanState: TimespanState,
     uiState: UiState,
     selectedCategoryId: String?,
+    isUncategorizedSelected: Boolean,
     navigateToDetails: (ModelTransaction) -> Unit,
     onTimespanSelected: (TimespanSelection) -> Unit,
     onRefresh: () -> Unit,
@@ -244,6 +247,7 @@ fun HomeScreen(
                             selectedTimespan = timespanState.selectedTimespan,
                             onCategoryClick = onCategoryClick,
                             selectedCategoryId = selectedCategoryId,
+                            isUncategorizedSelected = isUncategorizedSelected,
                         )
                     }
                 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreen.kt
@@ -99,35 +99,43 @@ import kotlin.math.roundToInt
 fun HomeScreen(component: HomeComponent) {
     val viewModel = koinViewModel<HomeScreenViewModel>()
     val transactionListState by viewModel.transactionListState.collectAsState()
+    val filteredTransactionListState by viewModel.filteredTransactionListState.collectAsState()
     val timespanState by viewModel.timespanState.collectAsState()
     val uiState by viewModel.uiState.collectAsState()
+    val selectedCategoryId by viewModel.selectedTagId.collectAsState()
 
     HomeScreen(
         transactionListState = transactionListState,
+        filteredTransactionListState = filteredTransactionListState,
         timespanState = timespanState,
         uiState = uiState,
+        selectedCategoryId = selectedCategoryId,
         navigateToDetails = component::navigateToDetails,
         onTimespanSelected = { viewModel.handleEvent(TransactionsEvent.SelectTimespan(it)) },
         onRefresh = { viewModel.handleEvent(event = TransactionsEvent.Refresh) },
         clearError = { viewModel.handleEvent(TransactionsEvent.ErrorShown(it)) },
         onDeleteTransaction = { viewModel.handleEvent(TransactionsEvent.DeleteTransaction(it)) },
         onToggleView = { viewModel.handleEvent(TransactionsEvent.ToggleTimespanView) },
-        onLoadMore = { viewModel.handleEvent(TransactionsEvent.LoadMore) }
+        onLoadMore = { viewModel.handleEvent(TransactionsEvent.LoadMore) },
+        onCategoryClick = { viewModel.handleEvent(TransactionsEvent.SelectTag(it)) },
     )
 }
 
 @Composable
 fun HomeScreen(
     transactionListState: TransactionListState,
+    filteredTransactionListState: TransactionListState,
     timespanState: TimespanState,
     uiState: UiState,
+    selectedCategoryId: String?,
     navigateToDetails: (ModelTransaction) -> Unit,
     onTimespanSelected: (TimespanSelection) -> Unit,
     onRefresh: () -> Unit,
     clearError: (String) -> Unit,
     onDeleteTransaction: (String) -> Unit,
     onToggleView: () -> Unit,
-    onLoadMore: () -> Unit
+    onLoadMore: () -> Unit,
+    onCategoryClick: (String) -> Unit,
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
     var dragOffset by remember { mutableStateOf(0f) }
@@ -233,7 +241,9 @@ fun HomeScreen(
                         CircularIndicator(
                             currency = stringResource(Res.string.currency_nok),
                             transactions = transactionListState.transactions,
-                            selectedTimespan = timespanState.selectedTimespan
+                            selectedTimespan = timespanState.selectedTimespan,
+                            onCategoryClick = onCategoryClick,
+                            selectedCategoryId = selectedCategoryId,
                         )
                     }
                 }
@@ -250,9 +260,9 @@ fun HomeScreen(
                 horizontalAlignment = Alignment.CenterHorizontally
             ) {
                 LazyTransactionList(
-                    isLoading = transactionListState.isLoading,
-                    isRefreshing = transactionListState.isRefreshing,
-                    transactions = transactionListState.transactions,
+                    isLoading = filteredTransactionListState.isLoading,
+                    isRefreshing = filteredTransactionListState.isRefreshing,
+                    transactions = filteredTransactionListState.transactions,
                     navigateToDetails = navigateToDetails,
                     onRefresh = onRefresh,
                     onDeleteTransaction = onDeleteTransaction

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenState.kt
@@ -56,6 +56,7 @@ data class HomeScreenState(
     val isYearView: Boolean = false,
     val isSyncing: Boolean = false,
     val isLoadingMore: Boolean = false,
+    val selectedTagId: String? = null,
 )
 
 sealed class TransactionsEvent {
@@ -65,4 +66,5 @@ sealed class TransactionsEvent {
     data class SelectTimespan(val timespan: TimespanSelection) : TransactionsEvent()
     data object ToggleTimespanView : TransactionsEvent()
     data object LoadMore : TransactionsEvent()
+    data class SelectTag(val tagId: String) : TransactionsEvent()
 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenState.kt
@@ -66,5 +66,5 @@ sealed class TransactionsEvent {
     data class SelectTimespan(val timespan: TimespanSelection) : TransactionsEvent()
     data object ToggleTimespanView : TransactionsEvent()
     data object LoadMore : TransactionsEvent()
-    data class SelectTag(val tagId: String) : TransactionsEvent()
+    data class SelectTag(val tagId: String?) : TransactionsEvent()
 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenState.kt
@@ -7,6 +7,12 @@ import com.banko.app.utils.getLastDayOfMonth
 import kotlinx.datetime.LocalDate
 import kotlinx.datetime.LocalDateTime
 
+sealed interface TagFilter {
+    data object None : TagFilter
+    data object Uncategorized : TagFilter
+    data class ById(val id: String) : TagFilter
+}
+
 data class YearMonth(val year: Int, val month: Int)
 
 sealed class TimespanSelection {
@@ -56,7 +62,7 @@ data class HomeScreenState(
     val isYearView: Boolean = false,
     val isSyncing: Boolean = false,
     val isLoadingMore: Boolean = false,
-    val selectedTagId: String? = null,
+    val tagFilter: TagFilter = TagFilter.None,
 )
 
 sealed class TransactionsEvent {

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenViewModel.kt
@@ -217,12 +217,13 @@ class HomeScreenViewModel(
         }
     }
 
-    private fun handleSelectTag(tagId: String) {
+    private fun handleSelectTag(tagId: String?) {
+        val normalizedTagId = tagId ?: "uncategorized"
         _state.update {
-            if (it.selectedTagId == tagId) {
+            if (it.selectedTagId == normalizedTagId) {
                 it.copy(selectedTagId = null)
             } else {
-                it.copy(selectedTagId = tagId)
+                it.copy(selectedTagId = normalizedTagId)
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenViewModel.kt
@@ -40,6 +40,19 @@ class HomeScreenViewModel(
         )
     }.stateIn(viewModelScope, SharingStarted.Eagerly, TransactionListState())
 
+    val filteredTransactionListState: StateFlow<TransactionListState> = _state.map { s ->
+        TransactionListState(
+            transactions = if (s.selectedTagId != null) {
+                s.transactions.filter { it.expenseTag?.id == s.selectedTagId }
+            } else {
+                s.transactions
+            },
+            isLoading = s.isLoading,
+            isRefreshing = s.isRefreshing,
+            isLoadingMore = s.isLoadingMore,
+        )
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, TransactionListState())
+
     val timespanState: StateFlow<TimespanState> = _state.map { s ->
         TimespanState(
             selectedTimespan = s.selectedTimespan,
@@ -56,6 +69,9 @@ class HomeScreenViewModel(
             isSyncing = s.isSyncing,
         )
     }.stateIn(viewModelScope, SharingStarted.Eagerly, UiState())
+
+    val selectedTagId: StateFlow<String?> = _state.map { it.selectedTagId }
+        .stateIn(viewModelScope, SharingStarted.Eagerly, null)
 
     private var transactionsJob: Job? = null
     private var syncJob: Job? = null
@@ -80,6 +96,7 @@ class HomeScreenViewModel(
             is TransactionsEvent.SelectTimespan -> handleSelectTimespan(event.timespan)
             is TransactionsEvent.ToggleTimespanView -> handleToggleView()
             is TransactionsEvent.LoadMore -> handleLoadMore()
+            is TransactionsEvent.SelectTag -> handleSelectTag(event.tagId)
         }
     }
 
@@ -200,6 +217,16 @@ class HomeScreenViewModel(
         }
     }
 
+    private fun handleSelectTag(tagId: String) {
+        _state.update {
+            if (it.selectedTagId == tagId) {
+                it.copy(selectedTagId = null)
+            } else {
+                it.copy(selectedTagId = tagId)
+            }
+        }
+    }
+
     private fun handleSelectTimespan(timespan: TimespanSelection) {
         when (timespan) {
             is TimespanSelection.Month -> {
@@ -208,7 +235,8 @@ class HomeScreenViewModel(
                     it.copy(
                         selectedTimespan = timespan,
                         indicatorDateState = LocalDateTime(timespan.ym.year, timespan.ym.month, 1, 0, 0),
-                        isYearView = false
+                        isYearView = false,
+                        selectedTagId = null,
                     )
                 }
             }
@@ -217,7 +245,8 @@ class HomeScreenViewModel(
                     it.copy(
                         selectedTimespan = timespan,
                         indicatorDateState = LocalDateTime(timespan.year, 1, 1, 0, 0),
-                        isYearView = true
+                        isYearView = true,
+                        selectedTagId = null,
                     )
                 }
             }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenViewModel.kt
@@ -42,10 +42,10 @@ class HomeScreenViewModel(
 
     val filteredTransactionListState: StateFlow<TransactionListState> = _state.map { s ->
         TransactionListState(
-            transactions = if (s.selectedTagId != null) {
-                s.transactions.filter { it.expenseTag?.id == s.selectedTagId }
-            } else {
-                s.transactions
+            transactions = when (s.selectedTagId) {
+                null -> s.transactions
+                "uncategorized" -> s.transactions.filter { it.expenseTag == null }
+                else -> s.transactions.filter { it.expenseTag?.id == s.selectedTagId }
             },
             isLoading = s.isLoading,
             isRefreshing = s.isRefreshing,

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenViewModel.kt
@@ -42,10 +42,10 @@ class HomeScreenViewModel(
 
     val filteredTransactionListState: StateFlow<TransactionListState> = _state.map { s ->
         TransactionListState(
-            transactions = when (s.selectedTagId) {
-                null -> s.transactions
-                "uncategorized" -> s.transactions.filter { it.expenseTag == null }
-                else -> s.transactions.filter { it.expenseTag?.id == s.selectedTagId }
+            transactions = when (val filter = s.tagFilter) {
+                is TagFilter.None -> s.transactions
+                is TagFilter.Uncategorized -> s.transactions.filter { it.expenseTag == null }
+                is TagFilter.ById -> s.transactions.filter { it.expenseTag?.id == filter.id }
             },
             isLoading = s.isLoading,
             isRefreshing = s.isRefreshing,
@@ -70,8 +70,17 @@ class HomeScreenViewModel(
         )
     }.stateIn(viewModelScope, SharingStarted.Eagerly, UiState())
 
-    val selectedTagId: StateFlow<String?> = _state.map { it.selectedTagId }
-        .stateIn(viewModelScope, SharingStarted.Eagerly, null)
+    val selectedCategoryId: StateFlow<String?> = _state.map { s ->
+        when (s.tagFilter) {
+            is TagFilter.None -> null
+            is TagFilter.Uncategorized -> null
+            is TagFilter.ById -> s.tagFilter.id
+        }
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, null)
+
+    val isUncategorizedSelected: StateFlow<Boolean> = _state.map { s ->
+        s.tagFilter is TagFilter.Uncategorized
+    }.stateIn(viewModelScope, SharingStarted.Eagerly, false)
 
     private var transactionsJob: Job? = null
     private var syncJob: Job? = null
@@ -218,13 +227,18 @@ class HomeScreenViewModel(
     }
 
     private fun handleSelectTag(tagId: String?) {
-        val normalizedTagId = tagId ?: "uncategorized"
         _state.update {
-            if (it.selectedTagId == normalizedTagId) {
-                it.copy(selectedTagId = null)
+            val newFilter: TagFilter = if (tagId == null) {
+                if (it.tagFilter is TagFilter.Uncategorized) TagFilter.None
+                else TagFilter.Uncategorized
             } else {
-                it.copy(selectedTagId = normalizedTagId)
+                if (it.tagFilter is TagFilter.ById && (it.tagFilter as TagFilter.ById).id == tagId) {
+                    TagFilter.None
+                } else {
+                    TagFilter.ById(tagId)
+                }
             }
+            it.copy(tagFilter = newFilter)
         }
     }
 
@@ -237,7 +251,7 @@ class HomeScreenViewModel(
                         selectedTimespan = timespan,
                         indicatorDateState = LocalDateTime(timespan.ym.year, timespan.ym.month, 1, 0, 0),
                         isYearView = false,
-                        selectedTagId = null,
+                        tagFilter = TagFilter.None,
                     )
                 }
             }
@@ -247,7 +261,7 @@ class HomeScreenViewModel(
                         selectedTimespan = timespan,
                         indicatorDateState = LocalDateTime(timespan.year, 1, 1, 0, 0),
                         isYearView = true,
-                        selectedTagId = null,
+                        tagFilter = TagFilter.None,
                     )
                 }
             }


### PR DESCRIPTION
## What
- Add tag filter state with toggle logic and a derived filtered transaction list
- Make category grid items clickable with visual highlight for the selected category
- Include uncategorized transactions in the circular indicator as an "Other" entry

## Why
- Enables users to filter the transaction list by tapping a spending category in the widget
- Provides clear visual feedback on which category is currently selected
- Ensures transactions without an expense tag are still visible and selectable in the gauge
- Uses idiomatic null semantics in the data model instead of a magic string sentinel