### PR TITLE
Improve error handling

### DIFF
--- a/composeApp/src/androidUnitTest/kotlin/com/banko/app/data/repository/TransactionRepositoryTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/banko/app/data/repository/TransactionRepositoryTest.kt
@@ -24,6 +24,7 @@ import org.junit.runner.RunWith
 import org.robolectric.RobolectricTestRunner
 import org.robolectric.annotation.Config
 import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
 import kotlin.test.assertTrue
 
 @RunWith(RobolectricTestRunner::class)
@@ -105,7 +106,11 @@ class TransactionRepositoryTest {
             remote.fetchTransactionsForDateRange(LocalDate(2024, 6, 1), LocalDate(2024, 6, 30))
         } returns Result.Error.HttpError(500, "Server error")
 
-        repo.fetchAndStoreTransactionsForDateRange(LocalDate(2024, 6, 1), LocalDate(2024, 6, 30))
+        val exception = runCatching {
+            repo.fetchAndStoreTransactionsForDateRange(LocalDate(2024, 6, 1), LocalDate(2024, 6, 30))
+        }.exceptionOrNull()
+        assertNotNull(exception)
+        assertTrue(exception is RuntimeException)
 
         val stored = repo.getTransactions(10).first()
         assertTrue(stored.isEmpty())
@@ -183,7 +188,9 @@ class TransactionRepositoryTest {
         )
         coEvery { remote.deleteTransaction("tx-keep") } returns Result.Error.HttpError(500, "Server error")
 
-        repo.deleteTransaction("tx-keep")
+        val exception = runCatching { repo.deleteTransaction("tx-keep") }.exceptionOrNull()
+        assertNotNull(exception)
+        assertTrue(exception is RuntimeException)
 
         val stored = repo.getTransactions(10).first()
         assertEquals(1, stored.size)

--- a/composeApp/src/androidUnitTest/kotlin/com/banko/app/domain/SaveNoteUseCaseTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/banko/app/domain/SaveNoteUseCaseTest.kt
@@ -8,6 +8,8 @@ import io.mockk.coVerify
 import io.mockk.mockk
 import kotlinx.coroutines.runBlocking
 import org.junit.Test
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
 
 class SaveNoteUseCaseTest {
 
@@ -41,7 +43,9 @@ class SaveNoteUseCaseTest {
 
         coEvery { apiTransactionsRepository.saveNote(id, note) } returns Result.Error.HttpError(500, "Server error")
 
-        useCase(id, note)
+        val exception = runCatching { useCase(id, note) }.exceptionOrNull()
+        assertNotNull(exception)
+        assertTrue(exception is RuntimeException)
 
         coVerify {
             apiTransactionsRepository.saveNote(id, note)
@@ -52,13 +56,15 @@ class SaveNoteUseCaseTest {
     }
 
     @Test
-    fun `should handle exception from API gracefully`() = runBlocking {
+    fun `should propagate exception from API`() = runBlocking {
         val id = "tx-1"
         val note = "Test note"
 
         coEvery { apiTransactionsRepository.saveNote(id, note) } throws RuntimeException("Network error")
 
-        useCase(id, note)
+        val exception = runCatching { useCase(id, note) }.exceptionOrNull()
+        assertNotNull(exception)
+        assertTrue(exception is RuntimeException)
 
         coVerify {
             apiTransactionsRepository.saveNote(id, note)

--- a/composeApp/src/androidUnitTest/kotlin/com/banko/app/ui/screens/home/HomeScreenViewModelTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/banko/app/ui/screens/home/HomeScreenViewModelTest.kt
@@ -3,6 +3,7 @@ package com.banko.app.ui.screens.home
 import com.banko.app.domain.model.ExpenseTag as DomainExpenseTag
 import com.banko.app.domain.model.Transaction as DomainTransaction
 import com.banko.app.data.repository.TransactionRepository
+import com.banko.app.ui.utils.ErrorType
 import io.mockk.coEvery
 import io.mockk.coVerify
 import io.mockk.mockk
@@ -226,17 +227,19 @@ class HomeScreenViewModelTest {
     }
 
     @Test
-    fun `should clear error when error shown event fires`() = runTest(testDispatcher) {
+    fun `should clear error when clearError is called`() = runTest(testDispatcher) {
         coEvery { repository.getTransactionsForDateRange(any(), any()) } returns flowOf(emptyList())
+        coEvery { repository.deleteTransaction(any()) } throws RuntimeException("Delete failed")
 
         val vm = HomeScreenViewModel(repository)
         advanceUntilIdle()
 
-        vm.state.value.copy(error = "Test error")
-
-        vm.handleEvent(TransactionsEvent.ErrorShown("Test error"))
+        vm.handleEvent(TransactionsEvent.DeleteTransaction("tx-1"))
         advanceUntilIdle()
+        assertNotNull(vm.state.value.error)
 
+        vm.clearError()
+        advanceUntilIdle()
         assertNull(vm.state.value.error)
     }
 
@@ -267,8 +270,11 @@ class HomeScreenViewModelTest {
         vm.handleEvent(TransactionsEvent.DeleteTransaction("tx-1"))
         advanceUntilIdle()
 
-        assertNotNull(vm.uiState.value.error)
-        assertEquals("Delete failed", vm.uiState.value.error)
+        val error = vm.uiState.value.error
+        assertNotNull(error)
+        assertEquals(ErrorType.GENERIC, error.type)
+        assertNotNull(error.fullMessage)
+        assertTrue(error.fullMessage!!.contains("Delete failed"))
     }
 
     @Test

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -62,4 +62,14 @@
     <string name="yearly_spendings">Yearly Spendings</string>
     <string name="yearly_earnings">Yearly Earnings</string>
     <string name="settings">Settings</string>
+    <string name="error_not_found">The requested resource was not found.</string>
+    <string name="error_conflict">This item already exists.</string>
+    <string name="error_server">A server error occurred. Please try again.</string>
+    <string name="error_network">No internet connection. Check your connection and try again.</string>
+    <string name="error_tag_assign">Could not save the selected tag. Please try again.</string>
+    <string name="error_tag_update">Could not update your tags. Please try again.</string>
+    <string name="error_generic">Something unexpected happened. Please try again.</string>
+    <string name="error_details_title">Error Details</string>
+    <string name="error_details_close">Close</string>
+    <string name="error_details_no_message">No additional error details available.</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/com/banko/app/data/repository/TransactionRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/data/repository/TransactionRepository.kt
@@ -38,8 +38,11 @@ class TransactionRepository(
 
     suspend fun fetchAndStoreTransactionsForDateRange(fromDate: LocalDate, toDate: LocalDate) {
         val result = remote.fetchTransactionsForDateRange(fromDate, toDate)
-        if (result is Result.Success) {
-            result.value.transactions.forEach { local.upsertTransaction(it) }
+        when (result) {
+            is Result.Error -> throw RuntimeException("Failed to fetch transactions: $result")
+            is Result.Success -> {
+                result.value.transactions.forEach { local.upsertTransaction(it) }
+            }
         }
     }
 
@@ -48,8 +51,9 @@ class TransactionRepository(
 
     suspend fun deleteTransaction(transactionId: String) {
         val apiResult = remote.deleteTransaction(transactionId)
-        if (apiResult is Result.Success) {
-            local.deleteTransaction(transactionId)
+        when (apiResult) {
+            is Result.Error -> throw RuntimeException("Failed to delete transaction: $apiResult")
+            is Result.Success -> local.deleteTransaction(transactionId)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/domain/SaveNoteUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/domain/SaveNoteUseCase.kt
@@ -9,13 +9,10 @@ class SaveNoteUseCase(
     private val transactionRepository: DatabaseTransactionRepository
 ) {
     suspend operator fun invoke(id: String, note: String) {
-        try {
-            val apiResult = apiTransactionsRepository.saveNote(id = id, text = note)
-            if (apiResult is Result.Success)  {
-                transactionRepository.saveNote(id, note)
-            }
-        } catch (ex: Exception){
-            println(ex)
+        val apiResult = apiTransactionsRepository.saveNote(id = id, text = note)
+        when (apiResult) {
+            is Result.Error -> throw RuntimeException("Failed to save note: $apiResult")
+            is Result.Success -> transactionRepository.saveNote(id, note)
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/ErrorSnackbarHost.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/ErrorSnackbarHost.kt
@@ -1,0 +1,51 @@
+// TODO: Remove this file (temporary debugging aid)
+package com.banko.app.ui.components
+
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Box
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import com.banko.app.ui.components.dialogs.ErrorDetailDialog
+
+@OptIn(ExperimentalFoundationApi::class)
+@Composable
+fun ErrorSnackbarHost(
+    hostState: SnackbarHostState,
+    rawError: String?,
+    modifier: Modifier = Modifier,
+) {
+    var showErrorDetailDialog by remember { mutableStateOf(false) }
+    var dialogFullError by remember { mutableStateOf("") }
+
+    SnackbarHost(
+        hostState = hostState,
+        modifier = modifier,
+    ) { data ->
+        Box(
+            modifier = Modifier.combinedClickable(
+                onClick = { },
+                onLongClick = {
+                    dialogFullError = rawError ?: data.visuals.message
+                    showErrorDetailDialog = true
+                }
+            )
+        ) {
+            Snackbar(snackbarData = data)
+        }
+    }
+
+    if (showErrorDetailDialog) {
+        ErrorDetailDialog(
+            fullError = dialogFullError,
+            onDismiss = { showErrorDetailDialog = false },
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/dialogs/ErrorDetailDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/dialogs/ErrorDetailDialog.kt
@@ -1,0 +1,40 @@
+// TODO: Remove this file (temporary debugging aid)
+package com.banko.app.ui.components.dialogs
+
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import banko.composeapp.generated.resources.Res
+import banko.composeapp.generated.resources.error_details_close
+import banko.composeapp.generated.resources.error_details_no_message
+import banko.composeapp.generated.resources.error_details_title
+import org.jetbrains.compose.resources.stringResource
+
+@Composable
+fun ErrorDetailDialog(
+    fullError: String?,
+    onDismiss: () -> Unit,
+) {
+    AlertDialog(
+        onDismissRequest = onDismiss,
+        title = {
+            Text(stringResource(Res.string.error_details_title))
+        },
+        text = {
+            SelectionContainer {
+                Text(
+                    text = fullError ?: stringResource(Res.string.error_details_no_message),
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
+        },
+        confirmButton = {
+            TextButton(onClick = onDismiss) {
+                Text(stringResource(Res.string.error_details_close))
+            }
+        }
+    )
+}

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/details/DetailScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/details/DetailScreenState.kt
@@ -5,4 +5,5 @@ import com.banko.app.ui.models.ExpenseTag
 data class DetailScreenState(
     val expenseTags: List<ExpenseTag> = emptyList(),
     val error: String? = null,
+    val rawError: String? = null,
 )

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/details/DetailScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/details/DetailScreenState.kt
@@ -1,9 +1,9 @@
 package com.banko.app.ui.screens.details
 
 import com.banko.app.ui.models.ExpenseTag
+import com.banko.app.ui.utils.ErrorState
 
 data class DetailScreenState(
     val expenseTags: List<ExpenseTag> = emptyList(),
-    val error: String? = null,
-    val rawError: String? = null,
+    val error: ErrorState? = null,
 )

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/details/DetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/details/DetailsScreen.kt
@@ -1,12 +1,22 @@
 package com.banko.app.ui.screens.details
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Snackbar
+import androidx.compose.material3.SnackbarHost
+import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Button
 import androidx.compose.material3.Card
@@ -83,11 +93,14 @@ fun DetailsScreen(component: DetailsComponent) {
         getExpenseTags = { viewModel.getExpenseTags() },
         assignExpenseTag = { id: String, tagId: String? -> viewModel.assignExpenseTag(id, tagId) },
         deleteTransaction = { id: String -> viewModel.deleteTransaction(id) },
-        goBack = { component.goBack() }
+        goBack = { component.goBack() },
+        error = screenState.error,
+        rawError = screenState.rawError,
+        clearError = { viewModel.clearError() }
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class)
+@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
 @Composable
 fun DetailsScreen(
     transactions: Transaction,
@@ -96,7 +109,10 @@ fun DetailsScreen(
     assignExpenseTag: (String, String?) -> Unit,
     getExpenseTags: () -> Unit,
     deleteTransaction: (String) -> Unit,
-    goBack: () -> Unit
+    goBack: () -> Unit,
+    error: String? = null,
+    rawError: String? = null,
+    clearError: () -> Unit = {},
 ) {
     var transaction by remember { mutableStateOf(transactions) }
     val transactionNote = remember { mutableStateOf(transaction.note ?: "") }
@@ -109,6 +125,19 @@ fun DetailsScreen(
     val tagMenuExpanded = remember { mutableStateOf(false) }
     val noteMenuExpanded = remember { mutableStateOf(false) }
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    val snackbarHostState = remember { SnackbarHostState() }
+
+    // TODO: Remove this error detail dialog (temporary debugging aid)
+    var showErrorDetailDialog by remember { mutableStateOf(false) }
+    var dialogFullError by remember { mutableStateOf("") }
+
+    LaunchedEffect(error) {
+        error?.let {
+            dialogFullError = rawError ?: it
+            snackbarHostState.showSnackbar(it)
+            clearError()
+        }
+    }
 
     if (isEditNote.value) {
         ModalBottomSheet(
@@ -142,9 +171,28 @@ fun DetailsScreen(
         )
     }
 
-    Column(
-        modifier = Modifier.fillMaxSize()
-    ) {
+    // TODO: Remove this custom Snackbar with long-press (temporary debugging aid)
+    Scaffold(
+        containerColor = MaterialTheme.colorScheme.surface,
+        snackbarHost = {
+            SnackbarHost(hostState = snackbarHostState) { data ->
+                Box(
+                    modifier = Modifier.combinedClickable(
+                        onClick = { },
+                        onLongClick = {
+                            dialogFullError = rawError ?: data.visuals.message
+                            showErrorDetailDialog = true
+                        }
+                    )
+                ) {
+                    Snackbar(snackbarData = data)
+                }
+            }
+        }
+    ) { _ ->
+        Column(
+            modifier = Modifier.fillMaxSize()
+        ) {
         Row {
             Text(
                 modifier = Modifier.padding(16.dp).weight(1f),
@@ -614,4 +662,26 @@ fun DetailsScreen(
             }
         }
     }
+
+    // TODO: Remove this error detail dialog (temporary debugging aid)
+    if (showErrorDetailDialog) {
+        AlertDialog(
+            onDismissRequest = { showErrorDetailDialog = false },
+            title = { Text("Error Details") },
+            text = {
+                SelectionContainer {
+                    Text(
+                        text = dialogFullError,
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
+            },
+            confirmButton = {
+                TextButton(onClick = { showErrorDetailDialog = false }) {
+                    Text("Close")
+                }
+            }
+        )
+    }
+}
 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/details/DetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/details/DetailsScreen.kt
@@ -1,21 +1,14 @@
 package com.banko.app.ui.screens.details
 
 import androidx.compose.foundation.BorderStroke
-import androidx.compose.foundation.ExperimentalFoundationApi
-import androidx.compose.foundation.combinedClickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.text.selection.SelectionContainer
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Snackbar
-import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.material3.Button
@@ -67,9 +60,12 @@ import banko.composeapp.generated.resources.ic_quill
 import banko.composeapp.generated.resources.ic_save
 import banko.composeapp.generated.resources.ic_tag
 import banko.composeapp.generated.resources.ic_tag_filled
+import com.banko.app.ui.components.ErrorSnackbarHost
 import com.banko.app.ui.models.ExpenseTag
 import com.banko.app.ui.models.Transaction
 import com.banko.app.ui.screens.details.DropDownMenus.ExpenseTagDropdown
+import com.banko.app.ui.utils.ErrorState
+import com.banko.app.ui.utils.toUserMessage
 import com.banko.app.ui.screens.details.DropDownMenus.MoreOptionsDropDown
 import com.banko.app.ui.screens.details.DropDownMenus.NoteDropDown
 import com.banko.app.ui.screens.details.bottomsheets.EditNoteBottomSheet
@@ -94,13 +90,12 @@ fun DetailsScreen(component: DetailsComponent) {
         assignExpenseTag = { id: String, tagId: String? -> viewModel.assignExpenseTag(id, tagId) },
         deleteTransaction = { id: String -> viewModel.deleteTransaction(id) },
         goBack = { component.goBack() },
-        error = screenState.error,
-        rawError = screenState.rawError,
+        errorState = screenState.error,
         clearError = { viewModel.clearError() }
     )
 }
 
-@OptIn(ExperimentalMaterial3Api::class, ExperimentalFoundationApi::class)
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun DetailsScreen(
     transactions: Transaction,
@@ -110,8 +105,7 @@ fun DetailsScreen(
     getExpenseTags: () -> Unit,
     deleteTransaction: (String) -> Unit,
     goBack: () -> Unit,
-    error: String? = null,
-    rawError: String? = null,
+    errorState: ErrorState? = null,
     clearError: () -> Unit = {},
 ) {
     var transaction by remember { mutableStateOf(transactions) }
@@ -127,13 +121,10 @@ fun DetailsScreen(
     val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
     val snackbarHostState = remember { SnackbarHostState() }
 
-    // TODO: Remove this error detail dialog (temporary debugging aid)
-    var showErrorDetailDialog by remember { mutableStateOf(false) }
-    var dialogFullError by remember { mutableStateOf("") }
+    val errorMessage = errorState?.let { it.type.toUserMessage() }
 
-    LaunchedEffect(error) {
-        error?.let {
-            dialogFullError = rawError ?: it
+    LaunchedEffect(errorMessage) {
+        errorMessage?.let {
             snackbarHostState.showSnackbar(it)
             clearError()
         }
@@ -171,23 +162,14 @@ fun DetailsScreen(
         )
     }
 
-    // TODO: Remove this custom Snackbar with long-press (temporary debugging aid)
+    // TODO: Remove ErrorSnackbarHost and revert to SnackbarHost (temporary)
     Scaffold(
         containerColor = MaterialTheme.colorScheme.surface,
         snackbarHost = {
-            SnackbarHost(hostState = snackbarHostState) { data ->
-                Box(
-                    modifier = Modifier.combinedClickable(
-                        onClick = { },
-                        onLongClick = {
-                            dialogFullError = rawError ?: data.visuals.message
-                            showErrorDetailDialog = true
-                        }
-                    )
-                ) {
-                    Snackbar(snackbarData = data)
-                }
-            }
+            ErrorSnackbarHost(
+                hostState = snackbarHostState,
+                rawError = errorState?.fullMessage,
+            )
         }
     ) { _ ->
         Column(
@@ -663,25 +645,6 @@ fun DetailsScreen(
         }
     }
 
-    // TODO: Remove this error detail dialog (temporary debugging aid)
-    if (showErrorDetailDialog) {
-        AlertDialog(
-            onDismissRequest = { showErrorDetailDialog = false },
-            title = { Text("Error Details") },
-            text = {
-                SelectionContainer {
-                    Text(
-                        text = dialogFullError,
-                        style = MaterialTheme.typography.bodySmall
-                    )
-                }
-            },
-            confirmButton = {
-                TextButton(onClick = { showErrorDetailDialog = false }) {
-                    Text("Close")
-                }
-            }
-        )
-    }
+
 }
 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/details/DetailsScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/details/DetailsScreenViewModel.kt
@@ -8,7 +8,8 @@ import com.banko.app.domain.AssignExpenseTagToTransactionUseCase
 import com.banko.app.domain.GetAllExpenseTagUseCase
 import com.banko.app.domain.SaveNoteUseCase
 import com.banko.app.data.repository.TransactionRepository
-import com.banko.app.ui.utils.toUserFacingErrorMessage
+import com.banko.app.ui.utils.ErrorState
+import com.banko.app.ui.utils.classifyError
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
@@ -49,8 +50,7 @@ class DetailsScreenViewModel(
                         updateTransactionUseCase.invoke(id, oldTagId)
                     }
                 }
-                val ufe = toUserFacingErrorMessage(e.message)
-                _screenState.update { it.copy(error = ufe.userMessage, rawError = ufe.fullError) }
+                _screenState.update { it.copy(error = ErrorState(classifyError(e), e.message)) }
             }
         }
     }
@@ -61,8 +61,7 @@ class DetailsScreenViewModel(
                 saveNoteUseCase.invoke(id = id, note = text)
                 _screenState.update { it.copy(error = null) }
             } catch (ex: Exception) {
-                val ufe = toUserFacingErrorMessage(ex.message)
-                _screenState.update { it.copy(error = ufe.userMessage, rawError = ufe.fullError) }
+                _screenState.update { it.copy(error = ErrorState(classifyError(ex), ex.message)) }
             }
         }
     }
@@ -73,13 +72,12 @@ class DetailsScreenViewModel(
                 transactionRepository.deleteTransaction(transactionId)
                 _screenState.update { it.copy(error = null) }
             } catch (ex: Exception) {
-                val ufe = toUserFacingErrorMessage(ex.message)
-                _screenState.update { it.copy(error = ufe.userMessage, rawError = ufe.fullError) }
+                _screenState.update { it.copy(error = ErrorState(classifyError(ex), ex.message)) }
             }
         }
     }
 
     fun clearError() {
-        _screenState.update { it.copy(error = null, rawError = null) }
+        _screenState.update { it.copy(error = null) }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/details/DetailsScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/details/DetailsScreenViewModel.kt
@@ -8,6 +8,7 @@ import com.banko.app.domain.AssignExpenseTagToTransactionUseCase
 import com.banko.app.domain.GetAllExpenseTagUseCase
 import com.banko.app.domain.SaveNoteUseCase
 import com.banko.app.data.repository.TransactionRepository
+import com.banko.app.ui.utils.toUserFacingErrorMessage
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
@@ -41,12 +42,15 @@ class DetailsScreenViewModel(
             try {
                 apiTagRepository.assignExpenseTag(id, expenseTagId)
                 updateTransactionUseCase.invoke(transactionId = id, expenseTagId = expenseTagId)
+                _screenState.update { it.copy(error = null) }
             } catch (e: Exception) {
                 if (previousTagId != expenseTagId) {
                     previousTagId?.let { oldTagId ->
                         updateTransactionUseCase.invoke(id, oldTagId)
                     }
                 }
+                val ufe = toUserFacingErrorMessage(e.message)
+                _screenState.update { it.copy(error = ufe.userMessage, rawError = ufe.fullError) }
             }
         }
     }
@@ -55,10 +59,10 @@ class DetailsScreenViewModel(
         viewModelScope.launch {
             try {
                 saveNoteUseCase.invoke(id = id, note = text)
+                _screenState.update { it.copy(error = null) }
             } catch (ex: Exception) {
-                screenState.value.copy(
-                    error = ex.message
-                )
+                val ufe = toUserFacingErrorMessage(ex.message)
+                _screenState.update { it.copy(error = ufe.userMessage, rawError = ufe.fullError) }
             }
         }
     }
@@ -67,11 +71,15 @@ class DetailsScreenViewModel(
         viewModelScope.launch {
             try {
                 transactionRepository.deleteTransaction(transactionId)
+                _screenState.update { it.copy(error = null) }
             } catch (ex: Exception) {
-                screenState.value.copy(
-                    error = ex.message
-                )
+                val ufe = toUserFacingErrorMessage(ex.message)
+                _screenState.update { it.copy(error = ufe.userMessage, rawError = ufe.fullError) }
             }
         }
+    }
+
+    fun clearError() {
+        _screenState.update { it.copy(error = null, rawError = null) }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreen.kt
@@ -17,8 +17,6 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.combinedClickable
-import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
@@ -43,13 +41,9 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Snackbar
-import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -88,10 +82,12 @@ import banko.composeapp.generated.resources.details
 import banko.composeapp.generated.resources.ic_delete
 import com.banko.app.ModelTransaction
 import com.banko.app.ui.components.CircularIndicator
+import com.banko.app.ui.components.ErrorSnackbarHost
 import com.banko.app.ui.components.ExpandableCard
 import com.banko.app.ui.components.ExpenseTag
 import com.banko.app.ui.models.Transaction
 import com.banko.app.ui.components.dialogs.TransactionDeleteDialog
+import com.banko.app.ui.utils.toUserMessage
 import kotlinx.datetime.Month
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -120,7 +116,7 @@ fun HomeScreen(component: HomeComponent) {
         navigateToDetails = component::navigateToDetails,
         onTimespanSelected = { viewModel.handleEvent(TransactionsEvent.SelectTimespan(it)) },
         onRefresh = { viewModel.handleEvent(event = TransactionsEvent.Refresh) },
-        clearError = { viewModel.handleEvent(TransactionsEvent.ErrorShown(it)) },
+        clearError = { viewModel.clearError() },
         onDeleteTransaction = { viewModel.handleEvent(TransactionsEvent.DeleteTransaction(it)) },
         onToggleView = { viewModel.handleEvent(TransactionsEvent.ToggleTimespanView) },
         onLoadMore = { viewModel.handleEvent(TransactionsEvent.LoadMore) },
@@ -128,7 +124,6 @@ fun HomeScreen(component: HomeComponent) {
     )
 }
 
-@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun HomeScreen(
     transactionListState: TransactionListState,
@@ -140,7 +135,7 @@ fun HomeScreen(
     navigateToDetails: (ModelTransaction) -> Unit,
     onTimespanSelected: (TimespanSelection) -> Unit,
     onRefresh: () -> Unit,
-    clearError: (String) -> Unit,
+    clearError: () -> Unit,
     onDeleteTransaction: (String) -> Unit,
     onToggleView: () -> Unit,
     onLoadMore: () -> Unit,
@@ -148,19 +143,16 @@ fun HomeScreen(
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
 
-    // TODO: Remove this error detail dialog (temporary debugging aid)
-    var showErrorDetailDialog by remember { mutableStateOf(false) }
-    var dialogFullError by remember { mutableStateOf("") }
-
     var dragOffset by remember { mutableStateOf(0f) }
     val swipeThreshold = 50f
     val currentTimespanState by rememberUpdatedState(timespanState)
 
-    LaunchedEffect(uiState.error) {
-        uiState.error?.let { error ->
-            dialogFullError = uiState.rawError ?: error
-            snackbarHostState.showSnackbar(error)
-            clearError(error)
+    val errorMessage = uiState.error?.let { it.type.toUserMessage() }
+
+    LaunchedEffect(errorMessage) {
+        errorMessage?.let {
+            snackbarHostState.showSnackbar(it)
+            clearError()
         }
     }
 
@@ -266,22 +258,13 @@ fun HomeScreen(
             }
         )
         LoadingProgressIndicator(isLoading = transactionListState.isLoadingMore)
-        // TODO: Remove this custom Snackbar with long-press (temporary debugging aid)
+        // TODO: Remove ErrorSnackbarHost and revert to SnackbarHost (temporary)
         Scaffold(
             snackbarHost = {
-                SnackbarHost(hostState = snackbarHostState) { data ->
-                    Box(
-                        modifier = Modifier.combinedClickable(
-                            onClick = { },
-                            onLongClick = {
-                                dialogFullError = uiState.rawError ?: data.visuals.message
-                                showErrorDetailDialog = true
-                            }
-                        )
-                    ) {
-                        Snackbar(snackbarData = data)
-                    }
-                }
+                ErrorSnackbarHost(
+                    hostState = snackbarHostState,
+                    rawError = uiState.error?.fullMessage,
+                )
             }
         ) { padding ->
             Column(
@@ -299,27 +282,6 @@ fun HomeScreen(
                     onDeleteTransaction = onDeleteTransaction
                 )
             }
-        }
-
-        // TODO: Remove this error detail dialog (temporary debugging aid)
-        if (showErrorDetailDialog) {
-            AlertDialog(
-                onDismissRequest = { showErrorDetailDialog = false },
-                title = { Text("Error Details") },
-                text = {
-                    SelectionContainer {
-                        Text(
-                            text = dialogFullError,
-                            style = MaterialTheme.typography.bodySmall
-                        )
-                    }
-                },
-                confirmButton = {
-                    TextButton(onClick = { showErrorDetailDialog = false }) {
-                        Text("Close")
-                    }
-                }
-            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreen.kt
@@ -17,6 +17,8 @@ import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.ExperimentalFoundationApi
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.text.selection.SelectionContainer
 import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.gestures.detectTapGestures
 import androidx.compose.foundation.layout.Arrangement
@@ -41,10 +43,13 @@ import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Snackbar
 import androidx.compose.material3.SnackbarHost
 import androidx.compose.material3.SnackbarHostState
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -123,6 +128,7 @@ fun HomeScreen(component: HomeComponent) {
     )
 }
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun HomeScreen(
     transactionListState: TransactionListState,
@@ -141,12 +147,18 @@ fun HomeScreen(
     onCategoryClick: (String?) -> Unit,
 ) {
     val snackbarHostState = remember { SnackbarHostState() }
+
+    // TODO: Remove this error detail dialog (temporary debugging aid)
+    var showErrorDetailDialog by remember { mutableStateOf(false) }
+    var dialogFullError by remember { mutableStateOf("") }
+
     var dragOffset by remember { mutableStateOf(0f) }
     val swipeThreshold = 50f
     val currentTimespanState by rememberUpdatedState(timespanState)
 
     LaunchedEffect(uiState.error) {
         uiState.error?.let { error ->
+            dialogFullError = uiState.rawError ?: error
             snackbarHostState.showSnackbar(error)
             clearError(error)
         }
@@ -254,8 +266,23 @@ fun HomeScreen(
             }
         )
         LoadingProgressIndicator(isLoading = transactionListState.isLoadingMore)
+        // TODO: Remove this custom Snackbar with long-press (temporary debugging aid)
         Scaffold(
-            snackbarHost = { SnackbarHost(snackbarHostState) }
+            snackbarHost = {
+                SnackbarHost(hostState = snackbarHostState) { data ->
+                    Box(
+                        modifier = Modifier.combinedClickable(
+                            onClick = { },
+                            onLongClick = {
+                                dialogFullError = uiState.rawError ?: data.visuals.message
+                                showErrorDetailDialog = true
+                            }
+                        )
+                    ) {
+                        Snackbar(snackbarData = data)
+                    }
+                }
+            }
         ) { padding ->
             Column(
                 modifier = Modifier
@@ -272,6 +299,27 @@ fun HomeScreen(
                     onDeleteTransaction = onDeleteTransaction
                 )
             }
+        }
+
+        // TODO: Remove this error detail dialog (temporary debugging aid)
+        if (showErrorDetailDialog) {
+            AlertDialog(
+                onDismissRequest = { showErrorDetailDialog = false },
+                title = { Text("Error Details") },
+                text = {
+                    SelectionContainer {
+                        Text(
+                            text = dialogFullError,
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
+                },
+                confirmButton = {
+                    TextButton(onClick = { showErrorDetailDialog = false }) {
+                        Text("Close")
+                    }
+                }
+            )
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenState.kt
@@ -47,6 +47,7 @@ data class TimespanState(
 
 data class UiState(
     val error: String? = null,
+    val rawError: String? = null,
     val isSyncing: Boolean = false,
 )
 
@@ -55,6 +56,7 @@ data class HomeScreenState(
     val isLoading: Boolean = false,
     val isRefreshing: Boolean = false,
     val error: String? = null,
+    val rawError: String? = null,
     val indicatorDateState: LocalDateTime = beginningOfCurrentMonth(),
     val selectedTimespan: TimespanSelection = TimespanSelection.Month(YearMonth(beginningOfCurrentMonth().year, beginningOfCurrentMonth().monthNumber)),
     val availableMonths: List<YearMonth> = emptyList(),

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenState.kt
@@ -1,6 +1,7 @@
 package com.banko.app.ui.screens.home
 
 import com.banko.app.ModelTransaction
+import com.banko.app.ui.utils.ErrorState
 import com.banko.app.utils.beginningOfCurrentMonth
 import com.banko.app.utils.computeYearEndDate
 import com.banko.app.utils.getLastDayOfMonth
@@ -46,8 +47,7 @@ data class TimespanState(
 )
 
 data class UiState(
-    val error: String? = null,
-    val rawError: String? = null,
+    val error: ErrorState? = null,
     val isSyncing: Boolean = false,
 )
 
@@ -55,8 +55,7 @@ data class HomeScreenState(
     val transactions: List<ModelTransaction> = emptyList(),
     val isLoading: Boolean = false,
     val isRefreshing: Boolean = false,
-    val error: String? = null,
-    val rawError: String? = null,
+    val error: ErrorState? = null,
     val indicatorDateState: LocalDateTime = beginningOfCurrentMonth(),
     val selectedTimespan: TimespanSelection = TimespanSelection.Month(YearMonth(beginningOfCurrentMonth().year, beginningOfCurrentMonth().monthNumber)),
     val availableMonths: List<YearMonth> = emptyList(),
@@ -69,7 +68,6 @@ data class HomeScreenState(
 
 sealed class TransactionsEvent {
     data object Refresh : TransactionsEvent()
-    data class ErrorShown(val error: String) : TransactionsEvent()
     data class DeleteTransaction(val transactionId: String) : TransactionsEvent()
     data class SelectTimespan(val timespan: TimespanSelection) : TransactionsEvent()
     data object ToggleTimespanView : TransactionsEvent()

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenViewModel.kt
@@ -4,7 +4,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.banko.app.data.repository.TransactionRepository
 import com.banko.app.ui.models.toUi
-import com.banko.app.ui.utils.toUserFacingErrorMessage
+import com.banko.app.ui.utils.ErrorState
+import com.banko.app.ui.utils.classifyError
 import com.banko.app.utils.beginningOfCurrentMonth
 import com.banko.app.utils.computeYearEndDate
 import com.banko.app.utils.getLastDayOfMonth
@@ -67,7 +68,6 @@ class HomeScreenViewModel(
     val uiState: StateFlow<UiState> = _state.map { s ->
         UiState(
             error = s.error,
-            rawError = s.rawError,
             isSyncing = s.isSyncing,
         )
     }.stateIn(viewModelScope, SharingStarted.Eagerly, UiState())
@@ -102,7 +102,6 @@ class HomeScreenViewModel(
     fun handleEvent(event: TransactionsEvent) {
         when (event) {
             is TransactionsEvent.Refresh -> refreshData()
-            is TransactionsEvent.ErrorShown -> clearError(event.error)
             is TransactionsEvent.DeleteTransaction -> handleDeleteTransaction(event.transactionId)
             is TransactionsEvent.SelectTimespan -> handleSelectTimespan(event.timespan)
             is TransactionsEvent.ToggleTimespanView -> handleToggleView()
@@ -120,16 +119,13 @@ class HomeScreenViewModel(
                 lastSyncTimestamps["${sel.fromDate}-${sel.toDate}"] = Clock.System.now().toEpochMilliseconds()
                 loadTransactionsForCurrentSelection()
             } catch (e: Exception) {
-                val ufe = toUserFacingErrorMessage(e.message)
-                _state.update { it.copy(isRefreshing = false, error = ufe.userMessage, rawError = ufe.fullError) }
+                _state.update { it.copy(isRefreshing = false, error = ErrorState(classifyError(e), e.message)) }
             }
         }
     }
 
-    private fun clearError(error: String) {
-        if (_state.value.error == error) {
-            _state.update { it.copy(error = null, rawError = null) }
-        }
+    fun clearError() {
+        _state.update { it.copy(error = null) }
     }
 
     private fun handleDeleteTransaction(transactionId: String) {
@@ -142,8 +138,7 @@ class HomeScreenViewModel(
                     )
                 }
             } catch (ex: Exception) {
-                val ufe = toUserFacingErrorMessage(ex.message)
-                _state.update { it.copy(error = ufe.userMessage, rawError = ufe.fullError) }
+                _state.update { it.copy(error = ErrorState(classifyError(ex), ex.message)) }
             }
         }
     }
@@ -183,8 +178,7 @@ class HomeScreenViewModel(
             val refreshedYears = refreshedMonths.map { it.year }.distinct().sortedDescending()
             _state.update { it.copy(availableMonths = refreshedMonths, availableYears = refreshedYears) }
         } catch (e: Exception) {
-            val ufe = toUserFacingErrorMessage(e.message)
-            _state.update { it.copy(error = ufe.userMessage, rawError = ufe.fullError) }
+            _state.update { it.copy(error = ErrorState(classifyError(e), e.message)) }
         }
     }
 
@@ -229,8 +223,7 @@ class HomeScreenViewModel(
                 _state.update { it.copy(availableMonths = months, availableYears = years) }
             }
         } catch (e: Exception) {
-            val ufe = toUserFacingErrorMessage(e.message)
-            _state.update { it.copy(error = ufe.userMessage, rawError = ufe.fullError) }
+            _state.update { it.copy(error = ErrorState(classifyError(e), e.message)) }
         }
     }
 
@@ -325,8 +318,7 @@ class HomeScreenViewModel(
                     )
                 }
             } catch (e: Exception) {
-                val ufe = toUserFacingErrorMessage(e.message)
-                _state.update { it.copy(isLoadingMore = false, error = ufe.userMessage, rawError = ufe.fullError) }
+                _state.update { it.copy(isLoadingMore = false, error = ErrorState(classifyError(e), e.message)) }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreenViewModel.kt
@@ -4,6 +4,7 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.banko.app.data.repository.TransactionRepository
 import com.banko.app.ui.models.toUi
+import com.banko.app.ui.utils.toUserFacingErrorMessage
 import com.banko.app.utils.beginningOfCurrentMonth
 import com.banko.app.utils.computeYearEndDate
 import com.banko.app.utils.getLastDayOfMonth
@@ -66,6 +67,7 @@ class HomeScreenViewModel(
     val uiState: StateFlow<UiState> = _state.map { s ->
         UiState(
             error = s.error,
+            rawError = s.rawError,
             isSyncing = s.isSyncing,
         )
     }.stateIn(viewModelScope, SharingStarted.Eagerly, UiState())
@@ -117,15 +119,16 @@ class HomeScreenViewModel(
                 repository.fetchAndStoreTransactionsForDateRange(sel.fromDate, sel.toDate)
                 lastSyncTimestamps["${sel.fromDate}-${sel.toDate}"] = Clock.System.now().toEpochMilliseconds()
                 loadTransactionsForCurrentSelection()
-            } catch (_: Exception) {
-                _state.update { it.copy(isRefreshing = false) }
+            } catch (e: Exception) {
+                val ufe = toUserFacingErrorMessage(e.message)
+                _state.update { it.copy(isRefreshing = false, error = ufe.userMessage, rawError = ufe.fullError) }
             }
         }
     }
 
     private fun clearError(error: String) {
         if (_state.value.error == error) {
-            _state.update { it.copy(error = null) }
+            _state.update { it.copy(error = null, rawError = null) }
         }
     }
 
@@ -139,7 +142,8 @@ class HomeScreenViewModel(
                     )
                 }
             } catch (ex: Exception) {
-                _state.update { it.copy(error = ex.message) }
+                val ufe = toUserFacingErrorMessage(ex.message)
+                _state.update { it.copy(error = ufe.userMessage, rawError = ufe.fullError) }
             }
         }
     }
@@ -178,7 +182,10 @@ class HomeScreenViewModel(
             val refreshedMonths = generateMonthRange(refreshedOldestDate)
             val refreshedYears = refreshedMonths.map { it.year }.distinct().sortedDescending()
             _state.update { it.copy(availableMonths = refreshedMonths, availableYears = refreshedYears) }
-        } catch (_: Exception) { }
+        } catch (e: Exception) {
+            val ufe = toUserFacingErrorMessage(e.message)
+            _state.update { it.copy(error = ufe.userMessage, rawError = ufe.fullError) }
+        }
     }
 
     private fun loadTransactionsForCurrentSelection() {
@@ -221,8 +228,9 @@ class HomeScreenViewModel(
                 val years = months.map { it.year }.distinct().sortedDescending()
                 _state.update { it.copy(availableMonths = months, availableYears = years) }
             }
-        } catch (_: Exception) {
-            // silent background sync failure
+        } catch (e: Exception) {
+            val ufe = toUserFacingErrorMessage(e.message)
+            _state.update { it.copy(error = ufe.userMessage, rawError = ufe.fullError) }
         }
     }
 
@@ -316,8 +324,9 @@ class HomeScreenViewModel(
                         isLoadingMore = false
                     )
                 }
-            } catch (_: Exception) {
-                _state.update { it.copy(isLoadingMore = false) }
+            } catch (e: Exception) {
+                val ufe = toUserFacingErrorMessage(e.message)
+                _state.update { it.copy(isLoadingMore = false, error = ufe.userMessage, rawError = ufe.fullError) }
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/SettingsScreen.kt
@@ -50,10 +50,10 @@ fun SettingsScreen(component: SettingsComponent) {
                     loadNewTags = { viewModel.loadExpenseTags() },
                     onTagUpdate = { viewModel.updateExpenseTag(it) },
                     onTagCreate = { name, color, isEarning -> viewModel.createExpenseTag(name, color, isEarning) },
-                    onTagDelete = { viewModel.deleteExpenseTag(it) }
-                    ) {
-                    currentBottomSheet = BottomSheetType.NONE
-                }
+                    onTagDelete = { viewModel.deleteExpenseTag(it) },
+                    clearError = { viewModel.clearError() },
+                    onClose = { currentBottomSheet = BottomSheetType.NONE }
+                )
 
                 BottomSheetType.NONE -> {} // Do nothing
             }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/SettingsScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/SettingsScreenState.kt
@@ -1,9 +1,9 @@
 package com.banko.app.ui.screens.settings
 
 import com.banko.app.ui.models.ExpenseTag
+import com.banko.app.ui.utils.ErrorState
 
 data class SettingsScreenState(
     val expenseTags: List<ExpenseTag> = emptyList(),
-    val error: String? = null,
-    val rawError: String? = null,
+    val error: ErrorState? = null,
 )

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/SettingsScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/SettingsScreenState.kt
@@ -4,4 +4,6 @@ import com.banko.app.ui.models.ExpenseTag
 
 data class SettingsScreenState(
     val expenseTags: List<ExpenseTag> = emptyList(),
+    val error: String? = null,
+    val rawError: String? = null,
 )

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/SettingsScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/SettingsScreenViewModel.kt
@@ -9,7 +9,8 @@ import com.banko.app.DatabaseExpenseTagRepository
 import com.banko.app.database.Entities.toModelItem
 import com.banko.app.ui.models.ExpenseTag
 import com.banko.app.ui.models.toDao
-import com.banko.app.ui.utils.toUserFacingErrorMessage
+import com.banko.app.ui.utils.ErrorState
+import com.banko.app.ui.utils.classifyError
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
@@ -44,8 +45,7 @@ class SettingsScreenViewModel(
                 }
                 _screenState.update { it.copy(error = null) }
             } catch (e: Exception) {
-                val ufe = toUserFacingErrorMessage(e.message)
-                _screenState.update { it.copy(error = ufe.userMessage, rawError = ufe.fullError) }
+                _screenState.update { it.copy(error = ErrorState(classifyError(e), e.message)) }
             }
         }
     }
@@ -57,8 +57,7 @@ class SettingsScreenViewModel(
                 dbRepository.upsertExpenseTag(result.toDao())
                 _screenState.update { it.copy(error = null) }
             } catch (e: Exception) {
-                val ufe = toUserFacingErrorMessage(e.message)
-                _screenState.update { it.copy(error = ufe.userMessage, rawError = ufe.fullError) }
+                _screenState.update { it.copy(error = ErrorState(classifyError(e), e.message)) }
             }
         }
     }
@@ -71,8 +70,7 @@ class SettingsScreenViewModel(
                 dbRepository.upsertExpenseTag(result.toDao())
                 _screenState.update { it.copy(error = null) }
             } catch (e: Exception) {
-                val ufe = toUserFacingErrorMessage(e.message)
-                _screenState.update { it.copy(error = ufe.userMessage, rawError = ufe.fullError) }
+                _screenState.update { it.copy(error = ErrorState(classifyError(e), e.message)) }
             }
         }
     }
@@ -84,13 +82,12 @@ class SettingsScreenViewModel(
                 dbRepository.deleteExpenseTag(expenseTagId)
                 _screenState.update { it.copy(error = null) }
             } catch (e: Exception) {
-                val ufe = toUserFacingErrorMessage(e.message)
-                _screenState.update { it.copy(error = ufe.userMessage, rawError = ufe.fullError) }
+                _screenState.update { it.copy(error = ErrorState(classifyError(e), e.message)) }
             }
         }
     }
 
     fun clearError() {
-        _screenState.update { it.copy(error = null, rawError = null) }
+        _screenState.update { it.copy(error = null) }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/SettingsScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/SettingsScreenViewModel.kt
@@ -9,6 +9,7 @@ import com.banko.app.DatabaseExpenseTagRepository
 import com.banko.app.database.Entities.toModelItem
 import com.banko.app.ui.models.ExpenseTag
 import com.banko.app.ui.models.toDao
+import com.banko.app.ui.utils.toUserFacingErrorMessage
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update
@@ -41,7 +42,11 @@ class SettingsScreenViewModel(
                 result.forEach {
                     dbRepository.upsertExpenseTag(it.toDao())
                 }
-            } catch (_: Exception) { }
+                _screenState.update { it.copy(error = null) }
+            } catch (e: Exception) {
+                val ufe = toUserFacingErrorMessage(e.message)
+                _screenState.update { it.copy(error = ufe.userMessage, rawError = ufe.fullError) }
+            }
         }
     }
 
@@ -50,7 +55,11 @@ class SettingsScreenViewModel(
             try {
                 val result = apiRepository.updateExpenseTag(expenseTag)
                 dbRepository.upsertExpenseTag(result.toDao())
-            } catch (_: Exception) { }
+                _screenState.update { it.copy(error = null) }
+            } catch (e: Exception) {
+                val ufe = toUserFacingErrorMessage(e.message)
+                _screenState.update { it.copy(error = ufe.userMessage, rawError = ufe.fullError) }
+            }
         }
     }
 
@@ -60,7 +69,11 @@ class SettingsScreenViewModel(
                 val result =
                     apiRepository.createExpenseTag(name, color.toArgb().toLong(), isEarning)
                 dbRepository.upsertExpenseTag(result.toDao())
-            } catch (_: Exception) { }
+                _screenState.update { it.copy(error = null) }
+            } catch (e: Exception) {
+                val ufe = toUserFacingErrorMessage(e.message)
+                _screenState.update { it.copy(error = ufe.userMessage, rawError = ufe.fullError) }
+            }
         }
     }
 
@@ -69,7 +82,15 @@ class SettingsScreenViewModel(
             try {
                 apiRepository.deleteExpenseTag(expenseTagId)
                 dbRepository.deleteExpenseTag(expenseTagId)
-            } catch (_: Exception) { }
+                _screenState.update { it.copy(error = null) }
+            } catch (e: Exception) {
+                val ufe = toUserFacingErrorMessage(e.message)
+                _screenState.update { it.copy(error = ufe.userMessage, rawError = ufe.fullError) }
+            }
         }
+    }
+
+    fun clearError() {
+        _screenState.update { it.copy(error = null, rawError = null) }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/bottomsheets/ExpenseTagsBottomSheetContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/bottomsheets/ExpenseTagsBottomSheetContent.kt
@@ -1,12 +1,18 @@
 package com.banko.app.ui.screens.settings.bottomsheets
 
+import androidx.compose.foundation.ExperimentalFoundationApi
+import androidx.compose.foundation.combinedClickable
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import kotlinx.coroutines.delay
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.text.selection.SelectionContainer
+import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -15,12 +21,15 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedIconButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -43,6 +52,7 @@ import com.banko.app.ui.screens.settings.bottomsheets.dialogs.ExpenseTagDeleteDi
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
+@OptIn(ExperimentalFoundationApi::class)
 @Composable
 fun ExpenseTagsBottomSheetContent(
     screenState: SettingsScreenState,
@@ -50,11 +60,22 @@ fun ExpenseTagsBottomSheetContent(
     onTagUpdate: (ExpenseTag) -> Unit,
     onTagCreate: (name: String, color: Color, isEarning: Boolean) -> Unit,
     onTagDelete: (expanseTagId: String) -> Unit,
-    onClose: () -> Unit
+    clearError: () -> Unit = {},
+    onClose: () -> Unit,
 ) {
 
     LaunchedEffect(Unit) {
         loadNewTags()
+    }
+
+    // TODO: Remove this error detail dialog (temporary debugging aid)
+    var showErrorDetailDialog by remember { mutableStateOf(false) }
+
+    LaunchedEffect(screenState.error) {
+        screenState.error?.let {
+            delay(3000)
+            clearError()
+        }
     }
 
     val isNewTag = remember { mutableStateOf(false) }
@@ -102,6 +123,47 @@ fun ExpenseTagsBottomSheetContent(
                     TagItem(tag = tag, onTagUpdate = onTagUpdate, onTagDelete = onTagDelete)
                 }
             }
+        }
+
+        screenState.error?.let { errorText ->
+            // TODO: Remove the combinedClickable wrapper to disable long-press (temporary)
+            Box(
+                modifier = Modifier
+                    .combinedClickable(
+                        onClick = { },
+                        onLongClick = {
+                            showErrorDetailDialog = true
+                        }
+                    )
+                    .padding(start = 12.dp, bottom = 8.dp)
+            ) {
+                Text(
+                    text = errorText,
+                    color = MaterialTheme.colorScheme.error,
+                    style = MaterialTheme.typography.bodySmall
+                )
+            }
+        }
+
+        // TODO: Remove this error detail dialog (temporary debugging aid)
+        if (showErrorDetailDialog) {
+            AlertDialog(
+                onDismissRequest = { showErrorDetailDialog = false },
+                title = { Text("Error Details") },
+                text = {
+                    SelectionContainer {
+                        Text(
+                            text = screenState.rawError ?: screenState.error ?: "",
+                            style = MaterialTheme.typography.bodySmall
+                        )
+                    }
+                },
+                confirmButton = {
+                    TextButton(onClick = { showErrorDetailDialog = false }) {
+                        Text("Close")
+                    }
+                }
+            )
         }
 
         Button(

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/bottomsheets/ExpenseTagsBottomSheetContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/bottomsheets/ExpenseTagsBottomSheetContent.kt
@@ -11,8 +11,6 @@ import androidx.compose.foundation.layout.padding
 import kotlinx.coroutines.delay
 import androidx.compose.foundation.lazy.LazyColumn
 import androidx.compose.foundation.lazy.itemsIndexed
-import androidx.compose.foundation.text.selection.SelectionContainer
-import androidx.compose.material3.AlertDialog
 import androidx.compose.material3.Button
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -21,7 +19,6 @@ import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedIconButton
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.TextField
 import androidx.compose.material3.TextFieldDefaults
 import androidx.compose.runtime.Composable
@@ -44,11 +41,13 @@ import banko.composeapp.generated.resources.ic_delete
 import banko.composeapp.generated.resources.ic_edit
 import banko.composeapp.generated.resources.ic_save
 import banko.composeapp.generated.resources.ic_tag_filled
+import com.banko.app.ui.components.dialogs.ErrorDetailDialog
 import com.banko.app.ui.models.ExpenseTag
 import com.banko.app.ui.screens.settings.SettingsScreenState
 import com.banko.app.ui.screens.settings.bottomsheets.dialogs.ExpenseTagAddNewDialog
 import com.banko.app.ui.screens.settings.bottomsheets.dialogs.ExpenseTagColorpickerDialog
 import com.banko.app.ui.screens.settings.bottomsheets.dialogs.ExpenseTagDeleteDialog
+import com.banko.app.ui.utils.toUserMessage
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 
@@ -67,9 +66,6 @@ fun ExpenseTagsBottomSheetContent(
     LaunchedEffect(Unit) {
         loadNewTags()
     }
-
-    // TODO: Remove this error detail dialog (temporary debugging aid)
-    var showErrorDetailDialog by remember { mutableStateOf(false) }
 
     LaunchedEffect(screenState.error) {
         screenState.error?.let {
@@ -125,45 +121,31 @@ fun ExpenseTagsBottomSheetContent(
             }
         }
 
-        screenState.error?.let { errorText ->
+        screenState.error?.let { errorState ->
+            var showDetail by remember { mutableStateOf(false) }
+
             // TODO: Remove the combinedClickable wrapper to disable long-press (temporary)
             Box(
                 modifier = Modifier
                     .combinedClickable(
                         onClick = { },
-                        onLongClick = {
-                            showErrorDetailDialog = true
-                        }
+                        onLongClick = { showDetail = true }
                     )
                     .padding(start = 12.dp, bottom = 8.dp)
             ) {
                 Text(
-                    text = errorText,
+                    text = errorState.type.toUserMessage(),
                     color = MaterialTheme.colorScheme.error,
                     style = MaterialTheme.typography.bodySmall
                 )
             }
-        }
 
-        // TODO: Remove this error detail dialog (temporary debugging aid)
-        if (showErrorDetailDialog) {
-            AlertDialog(
-                onDismissRequest = { showErrorDetailDialog = false },
-                title = { Text("Error Details") },
-                text = {
-                    SelectionContainer {
-                        Text(
-                            text = screenState.rawError ?: screenState.error ?: "",
-                            style = MaterialTheme.typography.bodySmall
-                        )
-                    }
-                },
-                confirmButton = {
-                    TextButton(onClick = { showErrorDetailDialog = false }) {
-                        Text("Close")
-                    }
-                }
-            )
+            if (showDetail) {
+                ErrorDetailDialog(
+                    fullError = errorState.fullMessage,
+                    onDismiss = { showDetail = false },
+                )
+            }
         }
 
         Button(

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/utils/UserFacingError.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/utils/UserFacingError.kt
@@ -1,44 +1,46 @@
 package com.banko.app.ui.utils
 
+import androidx.compose.runtime.Composable
 import banko.composeapp.generated.resources.Res
-import banko.composeapp.generated.resources.expense_tag_Other
+import banko.composeapp.generated.resources.error_conflict
+import banko.composeapp.generated.resources.error_generic
+import banko.composeapp.generated.resources.error_network
+import banko.composeapp.generated.resources.error_not_found
+import banko.composeapp.generated.resources.error_server
+import banko.composeapp.generated.resources.error_tag_assign
+import banko.composeapp.generated.resources.error_tag_update
 import org.jetbrains.compose.resources.stringResource
 
-data class UserFacingError(
-    val userMessage: String,
-    val fullError: String,
+enum class ErrorType {
+    NOT_FOUND, CONFLICT, SERVER_ERROR, NETWORK,
+    TAG_ASSIGN_FAILED, TAG_UPDATE_FAILED, GENERIC
+}
+
+data class ErrorState(
+    val type: ErrorType,
+    val fullMessage: String? = null,
 )
 
-fun toUserFacingErrorMessage(message: String?): UserFacingError {
-    val msg = message ?: "Unknown error"
+fun classifyError(throwable: Throwable): ErrorType {
+    val msg = throwable.message ?: return ErrorType.GENERIC
     return when {
-        msg.contains("HttpError(code=404") -> UserFacingError(
-            userMessage = "The requested resource was not found.",
-            fullError = msg
-        )
-        msg.contains("HttpError(code=409") -> UserFacingError(
-            userMessage = "This item already exists.",
-            fullError = msg
-        )
-        msg.contains("HttpError") -> UserFacingError(
-            userMessage = "A server error occurred. Please try again.",
-            fullError = msg
-        )
-        msg.contains("Network") || msg.contains("UnresolvedAddressException") -> UserFacingError(
-            userMessage = "No internet connection. Check your connection and try again.",
-            fullError = msg
-        )
-        msg.contains("Failed to assign expense tag") -> UserFacingError(
-            userMessage = "Could not save the selected tag. Please try again.",
-            fullError = msg
-        )
-        msg.contains("Failed to") && msg.contains("expense tag") -> UserFacingError(
-            userMessage = "Could not update your tags. Please try again.",
-            fullError = msg
-        )
-        else -> UserFacingError(
-            userMessage = "Something unexpected happened. Please try again.",
-            fullError = msg
-        )
+        msg.contains("HttpError(code=404") -> ErrorType.NOT_FOUND
+        msg.contains("HttpError(code=409") -> ErrorType.CONFLICT
+        msg.contains("HttpError") -> ErrorType.SERVER_ERROR
+        msg.contains("Network") || msg.contains("UnresolvedAddressException") -> ErrorType.NETWORK
+        msg.contains("Failed to assign expense tag") -> ErrorType.TAG_ASSIGN_FAILED
+        msg.contains("Failed to") && msg.contains("expense tag") -> ErrorType.TAG_UPDATE_FAILED
+        else -> ErrorType.GENERIC
     }
+}
+
+@Composable
+fun ErrorType.toUserMessage(): String = when (this) {
+    ErrorType.NOT_FOUND -> stringResource(Res.string.error_not_found)
+    ErrorType.CONFLICT -> stringResource(Res.string.error_conflict)
+    ErrorType.SERVER_ERROR -> stringResource(Res.string.error_server)
+    ErrorType.NETWORK -> stringResource(Res.string.error_network)
+    ErrorType.TAG_ASSIGN_FAILED -> stringResource(Res.string.error_tag_assign)
+    ErrorType.TAG_UPDATE_FAILED -> stringResource(Res.string.error_tag_update)
+    ErrorType.GENERIC -> stringResource(Res.string.error_generic)
 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/utils/UserFacingError.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/utils/UserFacingError.kt
@@ -1,0 +1,44 @@
+package com.banko.app.ui.utils
+
+import banko.composeapp.generated.resources.Res
+import banko.composeapp.generated.resources.expense_tag_Other
+import org.jetbrains.compose.resources.stringResource
+
+data class UserFacingError(
+    val userMessage: String,
+    val fullError: String,
+)
+
+fun toUserFacingErrorMessage(message: String?): UserFacingError {
+    val msg = message ?: "Unknown error"
+    return when {
+        msg.contains("HttpError(code=404") -> UserFacingError(
+            userMessage = "The requested resource was not found.",
+            fullError = msg
+        )
+        msg.contains("HttpError(code=409") -> UserFacingError(
+            userMessage = "This item already exists.",
+            fullError = msg
+        )
+        msg.contains("HttpError") -> UserFacingError(
+            userMessage = "A server error occurred. Please try again.",
+            fullError = msg
+        )
+        msg.contains("Network") || msg.contains("UnresolvedAddressException") -> UserFacingError(
+            userMessage = "No internet connection. Check your connection and try again.",
+            fullError = msg
+        )
+        msg.contains("Failed to assign expense tag") -> UserFacingError(
+            userMessage = "Could not save the selected tag. Please try again.",
+            fullError = msg
+        )
+        msg.contains("Failed to") && msg.contains("expense tag") -> UserFacingError(
+            userMessage = "Could not update your tags. Please try again.",
+            fullError = msg
+        )
+        else -> UserFacingError(
+            userMessage = "Something unexpected happened. Please try again.",
+            fullError = msg
+        )
+    }
+}

--- a/composeApp/src/commonTest/kotlin/com/banko/app/ui/utils/ErrorHandlingTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/banko/app/ui/utils/ErrorHandlingTest.kt
@@ -1,0 +1,52 @@
+package com.banko.app.ui.utils
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+
+class ErrorHandlingTest {
+
+    @Test
+    fun `classifyError returns GENERIC for unknown error`() {
+        assertEquals(ErrorType.GENERIC, classifyError(Exception("Something went wrong")))
+    }
+
+    @Test
+    fun `classifyError returns GENERIC for null message`() {
+        assertEquals(ErrorType.GENERIC, classifyError(Exception()))
+    }
+
+    @Test
+    fun `classifyError returns NOT_FOUND for 404 HttpError`() {
+        assertEquals(ErrorType.NOT_FOUND, classifyError(Exception("HttpError(code=404, response=...)")))
+    }
+
+    @Test
+    fun `classifyError returns CONFLICT for 409 HttpError`() {
+        assertEquals(ErrorType.CONFLICT, classifyError(Exception("HttpError(code=409, response=...)")))
+    }
+
+    @Test
+    fun `classifyError returns SERVER_ERROR for other HttpError`() {
+        assertEquals(ErrorType.SERVER_ERROR, classifyError(Exception("HttpError(code=500, response=...)")))
+    }
+
+    @Test
+    fun `classifyError returns NETWORK for network error`() {
+        assertEquals(ErrorType.NETWORK, classifyError(Exception("Network request failed")))
+    }
+
+    @Test
+    fun `classifyError returns NETWORK for UnresolvedAddressException`() {
+        assertEquals(ErrorType.NETWORK, classifyError(Exception("UnresolvedAddressException: host not found")))
+    }
+
+    @Test
+    fun `classifyError returns TAG_ASSIGN_FAILED`() {
+        assertEquals(ErrorType.TAG_ASSIGN_FAILED, classifyError(Exception("Failed to assign expense tag")))
+    }
+
+    @Test
+    fun `classifyError returns TAG_UPDATE_FAILED`() {
+        assertEquals(ErrorType.TAG_UPDATE_FAILED, classifyError(Exception("Failed to update expense tag")))
+    }
+}


### PR DESCRIPTION
## What
- Replace raw `String?` error fields with typed `ErrorState` model using `ErrorType` enum and centralized `classifyError()` function
- Add user-facing error string resources for all error categories to `strings.xml`
- Create reusable `ErrorSnackbarHost` (long-press for full details) and `ErrorDetailDialog` composables
- Propagate API errors from `TransactionRepository` and `SaveNoteUseCase` instead of silently swallowing failures
- Migrate HomeScreen, DetailsScreen, and SettingsScreen ViewModels and UIs to the typed error model
- Add `commonTest` for `classifyError()` and fix existing ViewModel tests for the new error types

## Why
- Centralizes error classification and enables consistent, type-safe user-facing messages across the app
- Eliminates hardcoded error strings in Kotlin code and keeps all user-facing text in resources
- Provides a uniform error display pattern across all screens with optional access to full technical details
- Prevents background loading, sync, and API failures from being silently dropped without user awareness
- Ensures uniform error handling behavior across all three screens
- Provides test coverage for the new error handling logic and fixes compilation errors from the refactoring