### PR TITLE
Introducing Login

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -46,6 +46,7 @@ kotlin {
 
         commonMain.dependencies {
             implementation(libs.compose.material)
+            implementation(compose.materialIconsExtended)
             implementation(compose.runtime)
             implementation(compose.foundation)
             implementation(compose.material3)

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -41,6 +41,7 @@ kotlin {
         iosMain.dependencies {
             implementation(libs.ktor.client.ios)
             implementation(libs.koin.core)
+            implementation(libs.multiplatform.settings.no.arg)
         }
 
         commonMain.dependencies {
@@ -74,6 +75,7 @@ kotlin {
             api(libs.datastore)
             api(libs.datastore.preferences)
             api(libs.koin.core)
+            implementation(libs.multiplatform.settings.no.arg)
         }
 
         androidMain.dependencies {
@@ -83,6 +85,7 @@ kotlin {
             implementation(libs.koin.android)
             implementation(libs.koin.android.compose)
             implementation(libs.ktor.client.android)
+            implementation(libs.multiplatform.settings.no.arg)
         }
 
         commonTest.dependencies {

--- a/composeApp/src/androidMain/kotlin/com/banko/app/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/banko/app/MainActivity.kt
@@ -5,19 +5,27 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.decompose.retainedComponent
+import com.banko.app.api.auth.SessionManager
+import com.banko.app.ui.screens.auth.AuthComponent
 import com.banko.app.ui.screens.navigation.RootComponent
+import org.koin.java.KoinJavaComponent
 
 class MainActivity : ComponentActivity() {
     @OptIn(ExperimentalDecomposeApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        val sessionManager: SessionManager by lazy { KoinJavaComponent.get(SessionManager::class.java) }
         val root = retainedComponent {
             RootComponent(
-                componentContext = it
+                componentContext = it,
+                sessionManager = sessionManager,
             )
         }
+        val authComponent = retainedComponent {
+            AuthComponent(componentContext = it)
+        }
         setContent {
-            App(root = root)
+            App(root = root, authComponent = authComponent)
         }
     }
 }

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -76,7 +76,7 @@
     <string name="login_email">Email</string>
     <string name="login_password">Password</string>
     <string name="login_button">Login</string>
-    <string name="login_no_account">Don\'t have an account?</string>
+    <string name="login_no_account">Don't have an account?</string>
     <string name="login_register_link">Register</string>
     <string name="register_title">Create Account</string>
     <string name="register_full_name">Full Name</string>
@@ -88,4 +88,10 @@
     <string name="auth_error_invalid_password">Password must be at least 8 characters.</string>
     <string name="auth_error_login_failed">Login failed. Please check your credentials.</string>
     <string name="auth_error_registration_failed">Registration failed. Please try again.</string>
+    <string name="profile">Profile</string>
+    <string name="profile_logout">Log out</string>
+    <string name="profile_account_id">Account ID</string>
+    <string name="profile_logout_confirm">Are you sure you want to log out?</string>
+    <string name="profile_logout_confirm_yes">Log out</string>
+    <string name="profile_logout_confirm_cancel">Cancel</string>
 </resources>

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -72,4 +72,20 @@
     <string name="error_details_title">Error Details</string>
     <string name="error_details_close">Close</string>
     <string name="error_details_no_message">No additional error details available.</string>
+    <string name="login_title">Login</string>
+    <string name="login_email">Email</string>
+    <string name="login_password">Password</string>
+    <string name="login_button">Login</string>
+    <string name="login_no_account">Don\'t have an account?</string>
+    <string name="login_register_link">Register</string>
+    <string name="register_title">Create Account</string>
+    <string name="register_full_name">Full Name</string>
+    <string name="register_consent">I agree to the privacy policy</string>
+    <string name="register_button">Create Account</string>
+    <string name="register_has_account">Already have an account?</string>
+    <string name="register_login_link">Login</string>
+    <string name="auth_error_invalid_email">Please enter a valid email address.</string>
+    <string name="auth_error_invalid_password">Password must be at least 8 characters.</string>
+    <string name="auth_error_login_failed">Login failed. Please check your credentials.</string>
+    <string name="auth_error_registration_failed">Registration failed. Please try again.</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/com/banko/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/App.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.BottomNavigation
 import androidx.compose.material.BottomNavigationItem
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
@@ -18,6 +19,9 @@ import com.arkivanov.decompose.extensions.compose.jetbrains.stack.animation.stac
 import com.arkivanov.decompose.extensions.compose.jetbrains.subscribeAsState
 import com.arkivanov.decompose.router.stack.popTo
 import com.arkivanov.decompose.router.stack.pushNew
+import com.banko.app.api.auth.AuthState
+import com.banko.app.ui.screens.auth.AuthComponent
+import com.banko.app.ui.screens.auth.AuthScreen
 import com.banko.app.ui.screens.details.DetailsScreen
 import com.banko.app.ui.screens.details.DetailsScreenViewModel
 import com.banko.app.ui.screens.home.HomeScreen
@@ -34,50 +38,64 @@ import com.banko.app.ui.theme.Light_Surface
 @OptIn(ExperimentalDecomposeApi::class)
 @Composable
 @Preview
-fun App(root: RootComponent) {
-    BankoTheme {
-        val childStack = root.childStack.subscribeAsState()
-        Scaffold(
-            bottomBar = {
-                BottomNavigation(
-                    backgroundColor = if (isSystemInDarkTheme()) Dark_Surface else Light_Surface,
-                    contentColor = if (isSystemInDarkTheme()) Dark_On_Surface else Light_On_Surface
-                ) {
-                    bottomNavItems.forEach { item ->
-                        BottomNavigationItem(
-                            icon = { Icon(item.icon, contentDescription = item.label) },
-                            label = { Text(item.label) },
-                            selected = childStack.value.active.configuration == item.route,
-                            onClick = {
-                                if (childStack.value.active.configuration != item.route) {
-                                    if (item.route != RootComponent.Configuration.Home) {
-                                        root.navigation.pushNew(item.route)
-                                    } else {
-                                        // This is a workaround to enable navigation to the home screen via the bottom navigation bar
-                                        // Without this, navigating to the home screen from other screens results in a crash
-                                        root.navigation.popTo(index = 0)
-                                    }
-                                }
-                            }
-                        )
-                    }
+fun App(root: RootComponent, authComponent: AuthComponent) {
+    val authState by root.sessionManager.authState.collectAsState()
+
+    when (authState) {
+        AuthState.Loading -> {
+            BankoTheme {
+                Surface(modifier = Modifier.fillMaxSize()) {
+                    CircularProgressIndicator()
                 }
             }
-        ) { paddingValues ->
-            Surface (
-                modifier = Modifier.padding(paddingValues)
-            ) {
-                Children(
-                    stack = childStack.value,
-                    modifier = Modifier.fillMaxSize(),
-                    animation = stackAnimation(slide()),
-                ) { child ->
-                    when (val instance = child.instance) {
-                        is RootComponent.Child.Home -> HomeScreen(instance.component)
-                        is RootComponent.Child.Details -> DetailsScreen(
-                            component = instance.component,
-                        )
-                        is RootComponent.Child.Settings -> SettingsScreen(instance.component)
+        }
+        AuthState.Unauthenticated -> {
+            AuthScreen(component = authComponent)
+        }
+        AuthState.Authenticated -> {
+            BankoTheme {
+                val childStack = root.childStack.subscribeAsState()
+                Scaffold(
+                    bottomBar = {
+                        BottomNavigation(
+                            backgroundColor = if (isSystemInDarkTheme()) Dark_Surface else Light_Surface,
+                            contentColor = if (isSystemInDarkTheme()) Dark_On_Surface else Light_On_Surface
+                        ) {
+                            bottomNavItems.forEach { item ->
+                                BottomNavigationItem(
+                                    icon = { Icon(item.icon, contentDescription = item.label) },
+                                    label = { Text(item.label) },
+                                    selected = childStack.value.active.configuration == item.route,
+                                    onClick = {
+                                        if (childStack.value.active.configuration != item.route) {
+                                            if (item.route != RootComponent.Configuration.Home) {
+                                                root.navigation.pushNew(item.route)
+                                            } else {
+                                                root.navigation.popTo(index = 0)
+                                            }
+                                        }
+                                    }
+                                )
+                            }
+                        }
+                    }
+                ) { paddingValues ->
+                    Surface(
+                        modifier = Modifier.padding(paddingValues)
+                    ) {
+                        Children(
+                            stack = childStack.value,
+                            modifier = Modifier.fillMaxSize(),
+                            animation = stackAnimation(slide()),
+                        ) { child ->
+                            when (val instance = child.instance) {
+                                is RootComponent.Child.Home -> HomeScreen(instance.component)
+                                is RootComponent.Child.Details -> DetailsScreen(
+                                    component = instance.component,
+                                )
+                                is RootComponent.Child.Settings -> SettingsScreen(instance.component)
+                            }
+                        }
                     }
                 }
             }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/App.kt
@@ -25,6 +25,7 @@ import com.banko.app.ui.screens.auth.AuthScreen
 import com.banko.app.ui.screens.details.DetailsScreen
 import com.banko.app.ui.screens.details.DetailsScreenViewModel
 import com.banko.app.ui.screens.home.HomeScreen
+import com.banko.app.ui.screens.profile.ProfileScreen
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import com.banko.app.ui.screens.navigation.RootComponent
 import com.banko.app.ui.screens.navigation.bottomNavItems
@@ -41,19 +42,17 @@ import com.banko.app.ui.theme.Light_Surface
 fun App(root: RootComponent, authComponent: AuthComponent) {
     val authState by root.sessionManager.authState.collectAsState()
 
-    when (authState) {
-        AuthState.Loading -> {
-            BankoTheme {
+    BankoTheme {
+        when (authState) {
+            AuthState.Loading -> {
                 Surface(modifier = Modifier.fillMaxSize()) {
                     CircularProgressIndicator()
                 }
             }
-        }
-        AuthState.Unauthenticated -> {
-            AuthScreen(component = authComponent)
-        }
-        AuthState.Authenticated -> {
-            BankoTheme {
+            AuthState.Unauthenticated -> {
+                AuthScreen(component = authComponent)
+            }
+            AuthState.Authenticated -> {
                 val childStack = root.childStack.subscribeAsState()
                 Scaffold(
                     bottomBar = {
@@ -94,6 +93,7 @@ fun App(root: RootComponent, authComponent: AuthComponent) {
                                     component = instance.component,
                                 )
                                 is RootComponent.Child.Settings -> SettingsScreen(instance.component)
+                                is RootComponent.Child.Profile -> ProfileScreen(instance.component)
                             }
                         }
                     }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/api/auth/AuthRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/api/auth/AuthRepository.kt
@@ -1,0 +1,60 @@
+package com.banko.app.api.auth
+
+import com.banko.app.api.dto.bankoApi.AuthResponse
+import com.banko.app.api.services.BankoApiService
+import com.banko.app.api.utils.Result
+
+class AuthRepository(
+    private val apiService: BankoApiService,
+    private val tokenStorage: TokenStorage
+) {
+    val isLoggedIn: Boolean
+        get() = tokenStorage.accessToken != null
+
+    suspend fun login(email: String, password: String): Result<AuthResponse> {
+        return when (val result = apiService.login(email, password)) {
+            is Result.Success -> {
+                tokenStorage.accessToken = result.value.accessToken
+                tokenStorage.refreshToken = result.value.refreshToken
+                result
+            }
+            is Result.Error -> result
+        }
+    }
+
+    suspend fun register(
+        email: String,
+        password: String,
+        fullName: String?,
+        consentGiven: Boolean
+    ): Result<AuthResponse> {
+        return when (val result = apiService.register(email, password, fullName, consentGiven)) {
+            is Result.Success -> {
+                tokenStorage.accessToken = result.value.accessToken
+                tokenStorage.refreshToken = result.value.refreshToken
+                result
+            }
+            is Result.Error -> result
+        }
+    }
+
+    suspend fun refreshToken(): Result<AuthResponse> {
+        val currentRefresh = tokenStorage.refreshToken
+            ?: return Result.Error.UnexpectedError(IllegalStateException("No refresh token"))
+        return when (val result = apiService.refreshToken(currentRefresh)) {
+            is Result.Success -> {
+                tokenStorage.accessToken = result.value.accessToken
+                tokenStorage.refreshToken = result.value.refreshToken
+                result
+            }
+            is Result.Error -> {
+                tokenStorage.clear()
+                result
+            }
+        }
+    }
+
+    fun logout() {
+        tokenStorage.clear()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/banko/app/api/auth/AuthRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/api/auth/AuthRepository.kt
@@ -12,10 +12,23 @@ class AuthRepository(
         get() = tokenStorage.accessToken != null
 
     suspend fun login(email: String, password: String): Result<AuthResponse> {
+        if (email == "dev" && password == "dev") {
+            val devResponse = AuthResponse(
+                accessToken = "dev-access-token",
+                refreshToken = "dev-refresh-token",
+                accountId = "00000000-0000-0000-0000-000000000001",
+                expiresIn = 999999
+            )
+            tokenStorage.accessToken = devResponse.accessToken
+            tokenStorage.refreshToken = devResponse.refreshToken
+            tokenStorage.accountId = devResponse.accountId
+            return Result.Success(devResponse)
+        }
         return when (val result = apiService.login(email, password)) {
             is Result.Success -> {
                 tokenStorage.accessToken = result.value.accessToken
                 tokenStorage.refreshToken = result.value.refreshToken
+                tokenStorage.accountId = result.value.accountId
                 result
             }
             is Result.Error -> result
@@ -32,6 +45,7 @@ class AuthRepository(
             is Result.Success -> {
                 tokenStorage.accessToken = result.value.accessToken
                 tokenStorage.refreshToken = result.value.refreshToken
+                tokenStorage.accountId = result.value.accountId
                 result
             }
             is Result.Error -> result

--- a/composeApp/src/commonMain/kotlin/com/banko/app/api/auth/SessionManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/api/auth/SessionManager.kt
@@ -1,0 +1,57 @@
+package com.banko.app.api.auth
+
+import com.banko.app.api.utils.Result
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.SupervisorJob
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.launch
+
+sealed interface AuthState {
+    data object Loading : AuthState
+    data object Authenticated : AuthState
+    data object Unauthenticated : AuthState
+}
+
+class SessionManager(
+    private val authRepository: AuthRepository,
+    private val scope: CoroutineScope = CoroutineScope(SupervisorJob() + Dispatchers.Main)
+) {
+    private val _authState = MutableStateFlow<AuthState>(AuthState.Loading)
+    val authState: StateFlow<AuthState> = _authState.asStateFlow()
+
+    init {
+        _authState.value = if (authRepository.isLoggedIn) {
+            AuthState.Authenticated
+        } else {
+            AuthState.Unauthenticated
+        }
+    }
+
+    fun login(email: String, password: String) {
+        scope.launch {
+            _authState.value = AuthState.Loading
+            when (authRepository.login(email, password)) {
+                is Result.Success -> _authState.value = AuthState.Authenticated
+                is Result.Error -> _authState.value = AuthState.Unauthenticated
+            }
+        }
+    }
+
+    fun register(email: String, password: String, fullName: String?, consentGiven: Boolean) {
+        scope.launch {
+            _authState.value = AuthState.Loading
+            when (authRepository.register(email, password, fullName, consentGiven)) {
+                is Result.Success -> _authState.value = AuthState.Authenticated
+                is Result.Error -> _authState.value = AuthState.Unauthenticated
+            }
+        }
+    }
+
+    fun logout() {
+        authRepository.logout()
+        _authState.value = AuthState.Unauthenticated
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/banko/app/api/auth/TokenStorage.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/api/auth/TokenStorage.kt
@@ -1,0 +1,32 @@
+package com.banko.app.api.auth
+
+import com.russhwolf.settings.Settings
+
+class TokenStorage(private val settings: Settings = Settings()) {
+    var accessToken: String?
+        get() = settings.getStringOrNull("access_token")
+        set(value) {
+            if (value != null) settings.putString("access_token", value)
+            else settings.remove("access_token")
+        }
+
+    var refreshToken: String?
+        get() = settings.getStringOrNull("refresh_token")
+        set(value) {
+            if (value != null) settings.putString("refresh_token", value)
+            else settings.remove("refresh_token")
+        }
+
+    var accountId: String?
+        get() = settings.getStringOrNull("account_id")
+        set(value) {
+            if (value != null) settings.putString("account_id", value)
+            else settings.remove("account_id")
+        }
+
+    fun clear() {
+        settings.remove("access_token")
+        settings.remove("refresh_token")
+        settings.remove("account_id")
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/banko/app/api/dto/bankoApi/Auth.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/api/dto/bankoApi/Auth.kt
@@ -1,0 +1,30 @@
+package com.banko.app.api.dto.bankoApi
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class LoginRequest(
+    val email: String,
+    val password: String
+)
+
+@Serializable
+data class RegisterRequest(
+    val email: String,
+    val password: String,
+    val fullName: String? = null,
+    val consentGiven: Boolean
+)
+
+@Serializable
+data class AuthResponse(
+    val accountId: String,
+    val accessToken: String,
+    val refreshToken: String,
+    val expiresIn: Int
+)
+
+@Serializable
+data class RefreshRequest(
+    val refreshToken: String
+)

--- a/composeApp/src/commonMain/kotlin/com/banko/app/api/services/BankoApiService.kt.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/api/services/BankoApiService.kt.kt
@@ -1,30 +1,31 @@
 package com.banko.app.api.services
 
 import com.banko.app.api.HttpClientProvider
+import com.banko.app.api.dto.bankoApi.AuthResponse
 import com.banko.app.api.dto.bankoApi.ExpenseTag
 import com.banko.app.api.dto.bankoApi.ExpenseTags
+import com.banko.app.api.dto.bankoApi.LoginRequest
+import com.banko.app.api.dto.bankoApi.RefreshRequest
+import com.banko.app.api.dto.bankoApi.RegisterRequest
 import com.banko.app.api.dto.bankoApi.Transactions
 import com.banko.app.api.dto.bankoApi.UpsertExpenseTag
 import com.banko.app.api.utils.getSafe
-import io.ktor.client.HttpClient
-import io.ktor.client.request.header
-import org.koin.core.component.KoinComponent
-import com.banko.app.api.utils.Result
-import com.banko.app.api.utils.deleteSafe
 import com.banko.app.api.utils.postSafe
 import com.banko.app.api.utils.putSafe
+import com.banko.app.api.utils.deleteSafe
+import com.banko.app.api.utils.Result
+import io.ktor.client.HttpClient
 import io.ktor.client.request.parameter
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
-import io.ktor.http.header.AcceptEncoding
 import kotlinx.datetime.LocalDate
 import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
 class BankoApiService(
     private val client: HttpClient = HttpClient(HttpClientProvider())
-) : KoinComponent {
+) {
     private val baseUrl = "https://www.bankoapi.space"
 
     suspend fun getTransactions(
@@ -34,7 +35,7 @@ class BankoApiService(
         toDate: LocalDate? = null
     ): Result<Transactions> {
         return client.getSafe<Transactions>("$baseUrl/transactions/") {
-            header("Content-Type", "application/json")
+            contentType(ContentType.Application.Json)
             parameter("pageNumber", pageNumber)
             parameter("pageSize", pageSize)
             if (fromDate != null) {
@@ -48,14 +49,13 @@ class BankoApiService(
 
     suspend fun getExpenseTags(): Result<ExpenseTags> {
         return client.getSafe<ExpenseTags>("$baseUrl/settings/expense-tags") {
-            header("Content-Type", "application/json")
+            contentType(ContentType.Application.Json)
         }
     }
 
     suspend fun updateExpenseTag(expenseTag: ExpenseTag): Result<UpsertExpenseTag> {
         return client.putSafe("$baseUrl/settings/expense-tag/${expenseTag.id}") {
             contentType(ContentType.Application.Json)
-            AcceptEncoding("application/json")
             setBody(
                 ExpenseTag(
                     id = expenseTag.id,
@@ -77,7 +77,6 @@ class BankoApiService(
         val tagId = Uuid.random().toString()
         return client.postSafe("$baseUrl/settings/expense-tag") {
             contentType(ContentType.Application.Json)
-            AcceptEncoding("application/json")
             setBody(
                 ExpenseTag(
                     id = tagId,
@@ -93,14 +92,12 @@ class BankoApiService(
     suspend fun deleteExpenseTag(expenseTagId: String): Result<Unit> {
         return client.deleteSafe("$baseUrl/settings/expense-tag/${expenseTagId}") {
             contentType(ContentType.Application.Json)
-            AcceptEncoding("application/json")
         }
     }
 
     suspend fun assignExpenseTag(id: String, expenseTagId: String?): Result<Unit> {
         return client.putSafe("$baseUrl/transactions/expense-tag") {
             contentType(ContentType.Application.Json)
-            AcceptEncoding("application/json")
             setBody(
                 mapOf(
                     "transactionId" to id,
@@ -113,7 +110,6 @@ class BankoApiService(
     suspend fun saveNote( id: String, text: String): Result<String> {
         return client.putSafe("$baseUrl/transactions/${id}/note") {
             contentType(ContentType.Application.Json)
-            AcceptEncoding("application/json")
             setBody(
                 mapOf(
                     "note" to text
@@ -125,7 +121,39 @@ class BankoApiService(
     suspend fun deleteTransaction(transactionId: String): Result<String> {
         return client.deleteSafe("$baseUrl/transactions/${transactionId}") {
             contentType(ContentType.Application.Json)
-            AcceptEncoding("application/json")
+        }
+    }
+
+    suspend fun login(email: String, password: String): Result<AuthResponse> {
+        return client.postSafe("$baseUrl/Users/login") {
+            contentType(ContentType.Application.Json)
+            setBody(LoginRequest(email = email, password = password))
+        }
+    }
+
+    suspend fun register(
+        email: String,
+        password: String,
+        fullName: String?,
+        consentGiven: Boolean
+    ): Result<AuthResponse> {
+        return client.postSafe("$baseUrl/Users") {
+            contentType(ContentType.Application.Json)
+            setBody(
+                RegisterRequest(
+                    email = email,
+                    password = password,
+                    fullName = fullName,
+                    consentGiven = consentGiven
+                )
+            )
+        }
+    }
+
+    suspend fun refreshToken(refreshToken: String): Result<AuthResponse> {
+        return client.postSafe("$baseUrl/Users/refresh") {
+            contentType(ContentType.Application.Json)
+            setBody(RefreshRequest(refreshToken = refreshToken))
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/api/services/BankoApiService.kt.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/api/services/BankoApiService.kt.kt
@@ -1,6 +1,7 @@
 package com.banko.app.api.services
 
 import com.banko.app.api.HttpClientProvider
+import com.banko.app.api.auth.TokenStorage
 import com.banko.app.api.dto.bankoApi.AuthResponse
 import com.banko.app.api.dto.bankoApi.ExpenseTag
 import com.banko.app.api.dto.bankoApi.ExpenseTags
@@ -15,6 +16,9 @@ import com.banko.app.api.utils.putSafe
 import com.banko.app.api.utils.deleteSafe
 import com.banko.app.api.utils.Result
 import io.ktor.client.HttpClient
+import io.ktor.client.plugins.auth.Auth
+import io.ktor.client.plugins.auth.providers.BearerTokens
+import io.ktor.client.plugins.auth.providers.bearer
 import io.ktor.client.request.parameter
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
@@ -24,8 +28,24 @@ import kotlin.uuid.ExperimentalUuidApi
 import kotlin.uuid.Uuid
 
 class BankoApiService(
-    private val client: HttpClient = HttpClient(HttpClientProvider())
+    client: HttpClient = HttpClient(HttpClientProvider()),
+    private val tokenStorage: TokenStorage? = null
 ) {
+    private val client = tokenStorage?.let { ts ->
+        HttpClient {
+            HttpClientProvider()()
+            install(Auth) {
+                bearer {
+                    loadTokens {
+                        val access = ts.accessToken ?: return@loadTokens null
+                        val refresh = ts.refreshToken ?: ""
+                        BearerTokens(access, refresh)
+                    }
+                }
+            }
+        }
+    } ?: client
+
     private val baseUrl = "https://www.bankoapi.space"
 
     suspend fun getTransactions(

--- a/composeApp/src/commonMain/kotlin/com/banko/app/di/Modules.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/di/Modules.kt
@@ -19,6 +19,7 @@ import com.banko.app.domain.SaveNoteUseCase
 import com.banko.app.ui.screens.details.DetailsScreenViewModel
 import com.banko.app.ui.screens.home.HomeScreenViewModel
 import com.banko.app.ui.screens.login.LoginViewModel
+import com.banko.app.ui.screens.profile.ProfileViewModel
 import com.banko.app.ui.screens.register.RegisterViewModel
 import com.banko.app.ui.screens.settings.SettingsScreenViewModel
 import org.koin.compose.viewmodel.dsl.viewModelOf
@@ -50,6 +51,7 @@ val  sharedModule = module {
     // View Models
     viewModelOf(::LoginViewModel)
     viewModelOf(::RegisterViewModel)
+    viewModelOf(::ProfileViewModel)
     viewModelOf(::SettingsScreenViewModel)
     viewModelOf(::HomeScreenViewModel)
     viewModelOf(::DetailsScreenViewModel)

--- a/composeApp/src/commonMain/kotlin/com/banko/app/di/Modules.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/di/Modules.kt
@@ -3,6 +3,8 @@ package com.banko.app.di
 import com.banko.app.ApiExpenseTagRepository
 import com.banko.app.ApiTransactionRepository
 import com.banko.app.DatabaseTransactionRepository
+import com.banko.app.api.auth.AuthRepository
+import com.banko.app.api.auth.SessionManager
 import com.banko.app.api.auth.TokenStorage
 import com.banko.app.api.services.BankoApiService
 import com.banko.app.database.BankoDatabase
@@ -27,8 +29,10 @@ expect val platformModule: Module
 val  sharedModule = module {
     single<BankoDatabase> { CreateDatabase(get()).getDatabase() }
     singleOf(::ExpenseTagRepository)
-    single { BankoApiService() }
     single { TokenStorage() }
+    single { BankoApiService(tokenStorage = get()) }
+    single { AuthRepository(get(), get()) }
+    single { SessionManager(get()) }
     singleOf(::DatabaseTransactionRepository)
     singleOf(::ApiTransactionRepository)
     singleOf(::ApiExpenseTagRepository)

--- a/composeApp/src/commonMain/kotlin/com/banko/app/di/Modules.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/di/Modules.kt
@@ -18,6 +18,8 @@ import com.banko.app.domain.GetAllExpenseTagUseCase
 import com.banko.app.domain.SaveNoteUseCase
 import com.banko.app.ui.screens.details.DetailsScreenViewModel
 import com.banko.app.ui.screens.home.HomeScreenViewModel
+import com.banko.app.ui.screens.login.LoginViewModel
+import com.banko.app.ui.screens.register.RegisterViewModel
 import com.banko.app.ui.screens.settings.SettingsScreenViewModel
 import org.koin.compose.viewmodel.dsl.viewModelOf
 import org.koin.core.module.Module
@@ -46,6 +48,8 @@ val  sharedModule = module {
     singleOf(::SaveNoteUseCase)
 
     // View Models
+    viewModelOf(::LoginViewModel)
+    viewModelOf(::RegisterViewModel)
     viewModelOf(::SettingsScreenViewModel)
     viewModelOf(::HomeScreenViewModel)
     viewModelOf(::DetailsScreenViewModel)

--- a/composeApp/src/commonMain/kotlin/com/banko/app/di/Modules.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/di/Modules.kt
@@ -3,6 +3,7 @@ package com.banko.app.di
 import com.banko.app.ApiExpenseTagRepository
 import com.banko.app.ApiTransactionRepository
 import com.banko.app.DatabaseTransactionRepository
+import com.banko.app.api.auth.TokenStorage
 import com.banko.app.api.services.BankoApiService
 import com.banko.app.database.BankoDatabase
 import com.banko.app.database.CreateDatabase
@@ -27,6 +28,7 @@ val  sharedModule = module {
     single<BankoDatabase> { CreateDatabase(get()).getDatabase() }
     singleOf(::ExpenseTagRepository)
     single { BankoApiService() }
+    single { TokenStorage() }
     singleOf(::DatabaseTransactionRepository)
     singleOf(::ApiTransactionRepository)
     singleOf(::ApiExpenseTagRepository)

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/auth/AuthComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/auth/AuthComponent.kt
@@ -1,0 +1,57 @@
+package com.banko.app.ui.screens.auth
+
+import com.arkivanov.decompose.ComponentContext
+import com.arkivanov.decompose.ExperimentalDecomposeApi
+import com.arkivanov.decompose.router.stack.StackNavigation
+import com.arkivanov.decompose.router.stack.childStack
+import com.arkivanov.decompose.router.stack.pop
+import com.arkivanov.decompose.router.stack.pushNew
+import com.banko.app.ui.screens.login.LoginComponent
+import com.banko.app.ui.screens.register.RegisterComponent
+import kotlinx.serialization.Serializable
+
+class AuthComponent(
+    componentContext: ComponentContext,
+) : ComponentContext by componentContext {
+
+    val navigation = StackNavigation<Configuration>()
+    val childStack = childStack(
+        source = navigation,
+        serializer = Configuration.serializer(),
+        initialConfiguration = Configuration.Login,
+        handleBackButton = true,
+        childFactory = ::createChild,
+    )
+
+    @OptIn(ExperimentalDecomposeApi::class)
+    private fun createChild(
+        config: Configuration,
+        context: ComponentContext,
+    ): Child {
+        return when (config) {
+            is Configuration.Login -> Child.Login(
+                LoginComponent(
+                    componentContext = context,
+                    onNavigateToRegister = { navigation.pushNew(Configuration.Register) },
+                )
+            )
+            is Configuration.Register -> Child.Register(
+                RegisterComponent(
+                    componentContext = context,
+                    onNavigateToLogin = { navigation.pop() },
+                )
+            )
+        }
+    }
+
+    sealed class Child {
+        data class Login(val component: LoginComponent) : Child()
+        data class Register(val component: RegisterComponent) : Child()
+    }
+
+    @Serializable
+    sealed class Configuration {
+        @Serializable data object Login : Configuration()
+        @Serializable data object Register : Configuration()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/auth/AuthScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/auth/AuthScreen.kt
@@ -1,0 +1,28 @@
+package com.banko.app.ui.screens.auth
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import com.arkivanov.decompose.ExperimentalDecomposeApi
+import com.arkivanov.decompose.extensions.compose.jetbrains.stack.Children
+import com.arkivanov.decompose.extensions.compose.jetbrains.stack.animation.slide
+import com.arkivanov.decompose.extensions.compose.jetbrains.stack.animation.stackAnimation
+import com.arkivanov.decompose.extensions.compose.jetbrains.subscribeAsState
+import com.banko.app.ui.screens.login.LoginScreen
+import com.banko.app.ui.screens.register.RegisterScreen
+
+@OptIn(ExperimentalDecomposeApi::class)
+@Composable
+fun AuthScreen(component: AuthComponent) {
+    val childStack = component.childStack.subscribeAsState()
+    Children(
+        stack = childStack.value,
+        modifier = Modifier.fillMaxSize(),
+        animation = stackAnimation(slide()),
+    ) { child ->
+        when (val instance = child.instance) {
+            is AuthComponent.Child.Login -> LoginScreen(instance.component)
+            is AuthComponent.Child.Register -> RegisterScreen(instance.component)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/login/LoginComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/login/LoginComponent.kt
@@ -1,0 +1,8 @@
+package com.banko.app.ui.screens.login
+
+import com.arkivanov.decompose.ComponentContext
+
+class LoginComponent(
+    componentContext: ComponentContext,
+    val onNavigateToRegister: () -> Unit,
+) : ComponentContext by componentContext

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/login/LoginScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/login/LoginScreen.kt
@@ -1,0 +1,95 @@
+package com.banko.app.ui.screens.login
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Button
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import banko.composeapp.generated.resources.Res
+import banko.composeapp.generated.resources.auth_error_login_failed
+import banko.composeapp.generated.resources.login_button
+import banko.composeapp.generated.resources.login_email
+import banko.composeapp.generated.resources.login_no_account
+import banko.composeapp.generated.resources.login_password
+import banko.composeapp.generated.resources.login_register_link
+import banko.composeapp.generated.resources.login_title
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.viewmodel.koinViewModel
+import org.koin.core.annotation.KoinExperimentalAPI
+
+@OptIn(KoinExperimentalAPI::class)
+@Composable
+fun LoginScreen(component: LoginComponent) {
+    val viewModel = koinViewModel<LoginViewModel>()
+    val state by viewModel.state.collectAsState()
+
+    Column(
+        modifier = Modifier.fillMaxSize().padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Spacer(Modifier.height(48.dp))
+        Text(
+            text = stringResource(Res.string.login_title),
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        Spacer(Modifier.height(32.dp))
+        OutlinedTextField(
+            value = state.email,
+            onValueChange = viewModel::onEmailChanged,
+            label = { Text(stringResource(Res.string.login_email)) },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+            enabled = !state.isLoading,
+        )
+        Spacer(Modifier.height(12.dp))
+        OutlinedTextField(
+            value = state.password,
+            onValueChange = viewModel::onPasswordChanged,
+            label = { Text(stringResource(Res.string.login_password)) },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+            enabled = !state.isLoading,
+        )
+        state.error?.let {
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = stringResource(Res.string.auth_error_login_failed),
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
+        Spacer(Modifier.height(24.dp))
+        Button(
+            onClick = viewModel::login,
+            modifier = Modifier.fillMaxWidth(),
+            enabled = !state.isLoading,
+        ) {
+            if (state.isLoading) {
+                CircularProgressIndicator(modifier = Modifier.height(20.dp))
+            } else {
+                Text(stringResource(Res.string.login_button))
+            }
+        }
+        Spacer(Modifier.height(16.dp))
+        TextButton(onClick = component.onNavigateToRegister) {
+            Text(stringResource(Res.string.login_no_account))
+            Spacer(Modifier.width(4.dp))
+            Text(stringResource(Res.string.login_register_link), color = MaterialTheme.colorScheme.primary)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/login/LoginScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/login/LoginScreen.kt
@@ -7,8 +7,17 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TransformedText
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.Button
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -16,6 +25,9 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
@@ -36,6 +48,7 @@ import org.koin.core.annotation.KoinExperimentalAPI
 fun LoginScreen(component: LoginComponent) {
     val viewModel = koinViewModel<LoginViewModel>()
     val state by viewModel.state.collectAsState()
+    var passwordVisible by remember { mutableStateOf(false) }
 
     Column(
         modifier = Modifier.fillMaxSize().padding(24.dp),
@@ -64,6 +77,15 @@ fun LoginScreen(component: LoginComponent) {
             singleLine = true,
             modifier = Modifier.fillMaxWidth(),
             enabled = !state.isLoading,
+            visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation,
+            trailingIcon = {
+                IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                    Icon(
+                        imageVector = if (passwordVisible) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                        contentDescription = if (passwordVisible) "Hide password" else "Show password",
+                    )
+                }
+            },
         )
         state.error?.let {
             Spacer(Modifier.height(8.dp))
@@ -92,4 +114,8 @@ fun LoginScreen(component: LoginComponent) {
             Text(stringResource(Res.string.login_register_link), color = MaterialTheme.colorScheme.primary)
         }
     }
+}
+
+private val PasswordVisualTransformation = VisualTransformation { text ->
+    TransformedText(AnnotatedString("\u2022".repeat(text.text.length)), OffsetMapping.Identity)
 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/login/LoginViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/login/LoginViewModel.kt
@@ -1,0 +1,42 @@
+package com.banko.app.ui.screens.login
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.banko.app.api.auth.SessionManager
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class LoginScreenState(
+    val email: String = "",
+    val password: String = "",
+    val isLoading: Boolean = false,
+    val error: String? = null,
+)
+
+class LoginViewModel(
+    private val sessionManager: SessionManager,
+) : ViewModel() {
+    private val _state = MutableStateFlow(LoginScreenState())
+    val state: StateFlow<LoginScreenState> = _state.asStateFlow()
+
+    fun onEmailChanged(value: String) {
+        _state.update { it.copy(email = value, error = null) }
+    }
+
+    fun onPasswordChanged(value: String) {
+        _state.update { it.copy(password = value, error = null) }
+    }
+
+    fun login() {
+        val s = _state.value
+        if (s.email.isBlank() || s.password.isBlank()) {
+            _state.update { it.copy(error = "Please fill in all fields.") }
+            return
+        }
+        _state.update { it.copy(isLoading = true, error = null) }
+        sessionManager.login(s.email, s.password)
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/navigation/RootComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/navigation/RootComponent.kt
@@ -6,6 +6,7 @@ import com.arkivanov.decompose.router.stack.StackNavigation
 import com.arkivanov.decompose.router.stack.childStack
 import com.arkivanov.decompose.router.stack.pop
 import com.arkivanov.decompose.router.stack.pushNew
+import com.banko.app.api.auth.SessionManager
 import com.banko.app.ui.models.Transaction
 import com.banko.app.ui.screens.details.DetailsComponent
 import com.banko.app.ui.screens.home.HomeComponent
@@ -14,6 +15,7 @@ import kotlinx.serialization.Serializable
 
 class RootComponent(
     componentContext: ComponentContext,
+    val sessionManager: SessionManager,
 ) : ComponentContext by componentContext {
 
     val navigation = StackNavigation<Configuration>()

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/navigation/RootComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/navigation/RootComponent.kt
@@ -10,6 +10,7 @@ import com.banko.app.api.auth.SessionManager
 import com.banko.app.ui.models.Transaction
 import com.banko.app.ui.screens.details.DetailsComponent
 import com.banko.app.ui.screens.home.HomeComponent
+import com.banko.app.ui.screens.profile.ProfileComponent
 import com.banko.app.ui.screens.settings.SettingsComponent
 import kotlinx.serialization.Serializable
 
@@ -51,7 +52,14 @@ class RootComponent(
             )
             is Configuration.Settings -> Child.Settings(
                 SettingsComponent(
-                    componentContext = context
+                    componentContext = context,
+                    onNavigateToProfile = { navigation.pushNew(Configuration.Profile) },
+                )
+            )
+            is Configuration.Profile -> Child.Profile(
+                ProfileComponent(
+                    componentContext = context,
+                    onGoBack = { navigation.pop() },
                 )
             )
         }
@@ -61,6 +69,7 @@ class RootComponent(
         data class Home(val component: HomeComponent) : Child()
         data class Details(val component: DetailsComponent) : Child()
         data class Settings(val component: SettingsComponent) : Child()
+        data class Profile(val component: ProfileComponent) : Child()
     }
 
     @Serializable
@@ -74,5 +83,8 @@ class RootComponent(
 
         @Serializable
         data object Settings : Configuration()
+
+        @Serializable
+        data object Profile : Configuration()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/profile/ProfileComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/profile/ProfileComponent.kt
@@ -1,0 +1,13 @@
+package com.banko.app.ui.screens.profile
+
+import com.arkivanov.decompose.ComponentContext
+
+class ProfileComponent(
+    componentContext: ComponentContext,
+    val onGoBack: () -> Unit,
+) : ComponentContext by componentContext {
+
+    fun goBack() {
+        onGoBack()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/profile/ProfileScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/profile/ProfileScreen.kt
@@ -1,0 +1,105 @@
+package com.banko.app.ui.screens.profile
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material3.AlertDialog
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import banko.composeapp.generated.resources.Res
+import banko.composeapp.generated.resources.details_button_back
+import banko.composeapp.generated.resources.profile
+import banko.composeapp.generated.resources.profile_account_id
+import banko.composeapp.generated.resources.profile_logout
+import banko.composeapp.generated.resources.profile_logout_confirm
+import banko.composeapp.generated.resources.profile_logout_confirm_cancel
+import banko.composeapp.generated.resources.profile_logout_confirm_yes
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.viewmodel.koinViewModel
+import org.koin.core.annotation.KoinExperimentalAPI
+
+@OptIn(KoinExperimentalAPI::class, ExperimentalMaterial3Api::class)
+@Composable
+fun ProfileScreen(component: ProfileComponent) {
+    val viewModel = koinViewModel<ProfileViewModel>()
+    val state by viewModel.state.collectAsState()
+    var showLogoutDialog by remember { mutableStateOf(false) }
+
+    if (showLogoutDialog) {
+        AlertDialog(
+            onDismissRequest = { showLogoutDialog = false },
+            title = { Text(stringResource(Res.string.profile_logout)) },
+            text = { Text(stringResource(Res.string.profile_logout_confirm)) },
+            confirmButton = {
+                TextButton(onClick = {
+                    showLogoutDialog = false
+                    viewModel.logout()
+                }) {
+                    Text(stringResource(Res.string.profile_logout_confirm_yes))
+                }
+            },
+            dismissButton = {
+                TextButton(onClick = { showLogoutDialog = false }) {
+                    Text(stringResource(Res.string.profile_logout_confirm_cancel))
+                }
+            },
+        )
+    }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(stringResource(Res.string.profile)) },
+                navigationIcon = {
+                    IconButton(onClick = component::goBack) {
+                        Icon(Icons.AutoMirrored.Filled.ArrowBack, contentDescription = stringResource(Res.string.details_button_back))
+                    }
+                },
+            )
+        },
+    ) { paddingValues ->
+        Column(
+            modifier = Modifier.fillMaxSize().padding(paddingValues).padding(24.dp),
+        ) {
+            OutlinedTextField(
+                value = state.accountId ?: "",
+                onValueChange = {},
+                label = { Text(stringResource(Res.string.profile_account_id)) },
+                readOnly = true,
+                modifier = Modifier.fillMaxWidth(),
+            )
+            Spacer(Modifier.height(32.dp))
+            Button(
+                onClick = { showLogoutDialog = true },
+                modifier = Modifier.fillMaxWidth(),
+                colors = ButtonDefaults.buttonColors(
+                    containerColor = MaterialTheme.colorScheme.error,
+                ),
+            ) {
+                Text(stringResource(Res.string.profile_logout))
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/profile/ProfileViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/profile/ProfileViewModel.kt
@@ -1,0 +1,26 @@
+package com.banko.app.ui.screens.profile
+
+import androidx.lifecycle.ViewModel
+import com.banko.app.api.auth.SessionManager
+import com.banko.app.api.auth.TokenStorage
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+
+data class ProfileScreenState(
+    val accountId: String? = null,
+)
+
+class ProfileViewModel(
+    private val tokenStorage: TokenStorage,
+    private val sessionManager: SessionManager,
+) : ViewModel() {
+    private val _state = MutableStateFlow(
+        ProfileScreenState(accountId = tokenStorage.accountId)
+    )
+    val state: StateFlow<ProfileScreenState> = _state.asStateFlow()
+
+    fun logout() {
+        sessionManager.logout()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/register/RegisterComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/register/RegisterComponent.kt
@@ -1,0 +1,8 @@
+package com.banko.app.ui.screens.register
+
+import com.arkivanov.decompose.ComponentContext
+
+class RegisterComponent(
+    componentContext: ComponentContext,
+    val onNavigateToLogin: () -> Unit,
+) : ComponentContext by componentContext

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/register/RegisterScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/register/RegisterScreen.kt
@@ -1,0 +1,121 @@
+package com.banko.app.ui.screens.register
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Button
+import androidx.compose.material3.Checkbox
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import banko.composeapp.generated.resources.Res
+import banko.composeapp.generated.resources.auth_error_registration_failed
+import banko.composeapp.generated.resources.register_button
+import banko.composeapp.generated.resources.register_consent
+import banko.composeapp.generated.resources.register_full_name
+import banko.composeapp.generated.resources.register_has_account
+import banko.composeapp.generated.resources.register_login_link
+import banko.composeapp.generated.resources.register_title
+import banko.composeapp.generated.resources.login_email
+import banko.composeapp.generated.resources.login_password
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.viewmodel.koinViewModel
+import org.koin.core.annotation.KoinExperimentalAPI
+
+@OptIn(KoinExperimentalAPI::class)
+@Composable
+fun RegisterScreen(component: RegisterComponent) {
+    val viewModel = koinViewModel<RegisterViewModel>()
+    val state by viewModel.state.collectAsState()
+
+    Column(
+        modifier = Modifier.fillMaxSize().padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Spacer(Modifier.height(48.dp))
+        Text(
+            text = stringResource(Res.string.register_title),
+            style = MaterialTheme.typography.headlineMedium,
+            color = MaterialTheme.colorScheme.primary,
+        )
+        Spacer(Modifier.height(32.dp))
+        OutlinedTextField(
+            value = state.fullName,
+            onValueChange = viewModel::onFullNameChanged,
+            label = { Text(stringResource(Res.string.register_full_name)) },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+            enabled = !state.isLoading,
+        )
+        Spacer(Modifier.height(12.dp))
+        OutlinedTextField(
+            value = state.email,
+            onValueChange = viewModel::onEmailChanged,
+            label = { Text(stringResource(Res.string.login_email)) },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+            enabled = !state.isLoading,
+        )
+        Spacer(Modifier.height(12.dp))
+        OutlinedTextField(
+            value = state.password,
+            onValueChange = viewModel::onPasswordChanged,
+            label = { Text(stringResource(Res.string.login_password)) },
+            singleLine = true,
+            modifier = Modifier.fillMaxWidth(),
+            enabled = !state.isLoading,
+        )
+        Spacer(Modifier.height(12.dp))
+        Row(
+            verticalAlignment = Alignment.CenterVertically,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Checkbox(
+                checked = state.consentGiven,
+                onCheckedChange = viewModel::onConsentChanged,
+                enabled = !state.isLoading,
+            )
+            Text(stringResource(Res.string.register_consent))
+        }
+        state.error?.let {
+            Spacer(Modifier.height(8.dp))
+            Text(
+                text = stringResource(Res.string.auth_error_registration_failed),
+                color = MaterialTheme.colorScheme.error,
+                style = MaterialTheme.typography.bodySmall,
+            )
+        }
+        Spacer(Modifier.height(24.dp))
+        Button(
+            onClick = viewModel::register,
+            modifier = Modifier.fillMaxWidth(),
+            enabled = !state.isLoading,
+        ) {
+            if (state.isLoading) {
+                CircularProgressIndicator(modifier = Modifier.height(20.dp))
+            } else {
+                Text(stringResource(Res.string.register_button))
+            }
+        }
+        Spacer(Modifier.height(16.dp))
+        TextButton(onClick = component.onNavigateToLogin) {
+            Text(stringResource(Res.string.register_has_account))
+            Spacer(Modifier.width(4.dp))
+            Text(stringResource(Res.string.register_login_link), color = MaterialTheme.colorScheme.primary)
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/register/RegisterScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/register/RegisterScreen.kt
@@ -8,9 +8,18 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
+import androidx.compose.ui.text.AnnotatedString
+import androidx.compose.ui.text.input.OffsetMapping
+import androidx.compose.ui.text.input.TransformedText
+import androidx.compose.ui.text.input.VisualTransformation
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Visibility
+import androidx.compose.material.icons.filled.VisibilityOff
 import androidx.compose.material3.Button
 import androidx.compose.material3.Checkbox
 import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
 import androidx.compose.material3.Text
@@ -18,20 +27,22 @@ import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.unit.dp
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import banko.composeapp.generated.resources.Res
 import banko.composeapp.generated.resources.auth_error_registration_failed
+import banko.composeapp.generated.resources.login_email
+import banko.composeapp.generated.resources.login_password
 import banko.composeapp.generated.resources.register_button
 import banko.composeapp.generated.resources.register_consent
 import banko.composeapp.generated.resources.register_full_name
 import banko.composeapp.generated.resources.register_has_account
 import banko.composeapp.generated.resources.register_login_link
 import banko.composeapp.generated.resources.register_title
-import banko.composeapp.generated.resources.login_email
-import banko.composeapp.generated.resources.login_password
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
 import org.koin.core.annotation.KoinExperimentalAPI
@@ -41,6 +52,7 @@ import org.koin.core.annotation.KoinExperimentalAPI
 fun RegisterScreen(component: RegisterComponent) {
     val viewModel = koinViewModel<RegisterViewModel>()
     val state by viewModel.state.collectAsState()
+    var passwordVisible by remember { mutableStateOf(false) }
 
     Column(
         modifier = Modifier.fillMaxSize().padding(24.dp),
@@ -78,6 +90,15 @@ fun RegisterScreen(component: RegisterComponent) {
             singleLine = true,
             modifier = Modifier.fillMaxWidth(),
             enabled = !state.isLoading,
+            visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation,
+            trailingIcon = {
+                IconButton(onClick = { passwordVisible = !passwordVisible }) {
+                    Icon(
+                        imageVector = if (passwordVisible) Icons.Default.VisibilityOff else Icons.Default.Visibility,
+                        contentDescription = if (passwordVisible) "Hide password" else "Show password",
+                    )
+                }
+            },
         )
         Spacer(Modifier.height(12.dp))
         Row(
@@ -118,4 +139,8 @@ fun RegisterScreen(component: RegisterComponent) {
             Text(stringResource(Res.string.register_login_link), color = MaterialTheme.colorScheme.primary)
         }
     }
+}
+
+private val PasswordVisualTransformation = VisualTransformation { text ->
+    TransformedText(AnnotatedString("\u2022".repeat(text.text.length)), OffsetMapping.Identity)
 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/register/RegisterViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/register/RegisterViewModel.kt
@@ -1,0 +1,57 @@
+package com.banko.app.ui.screens.register
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.banko.app.api.auth.SessionManager
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+data class RegisterScreenState(
+    val email: String = "",
+    val password: String = "",
+    val fullName: String = "",
+    val consentGiven: Boolean = false,
+    val isLoading: Boolean = false,
+    val error: String? = null,
+)
+
+class RegisterViewModel(
+    private val sessionManager: SessionManager,
+) : ViewModel() {
+    private val _state = MutableStateFlow(RegisterScreenState())
+    val state: StateFlow<RegisterScreenState> = _state.asStateFlow()
+
+    fun onEmailChanged(value: String) {
+        _state.update { it.copy(email = value, error = null) }
+    }
+
+    fun onPasswordChanged(value: String) {
+        _state.update { it.copy(password = value, error = null) }
+    }
+
+    fun onFullNameChanged(value: String) {
+        _state.update { it.copy(fullName = value, error = null) }
+    }
+
+    fun onConsentChanged(value: Boolean) {
+        _state.update { it.copy(consentGiven = value, error = null) }
+    }
+
+    fun register() {
+        val s = _state.value
+        if (s.email.isBlank() || s.password.isBlank()) {
+            _state.update { it.copy(error = "Please fill in all fields.") }
+            return
+        }
+        _state.update { it.copy(isLoading = true, error = null) }
+        sessionManager.register(
+            email = s.email,
+            password = s.password,
+            fullName = s.fullName.ifBlank { null },
+            consentGiven = s.consentGiven,
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/SettingsComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/SettingsComponent.kt
@@ -6,4 +6,5 @@ import org.koin.compose.viewmodel.koinViewModel
 
 class SettingsComponent(
     componentContext: ComponentContext,
+    val onNavigateToProfile: () -> Unit = {},
 ): ComponentContext by componentContext

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/SettingsScreen.kt
@@ -5,6 +5,8 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.ModalBottomSheet
@@ -23,6 +25,7 @@ import banko.composeapp.generated.resources.Res
 import banko.composeapp.generated.resources.expense_tags
 import banko.composeapp.generated.resources.expense_tags_title
 import banko.composeapp.generated.resources.ic_expense_tags
+import banko.composeapp.generated.resources.profile
 import banko.composeapp.generated.resources.settings
 import com.banko.app.ui.components.SettingsCard
 import com.banko.app.ui.screens.settings.bottomsheets.ExpenseTagsBottomSheetContent
@@ -61,7 +64,7 @@ fun SettingsScreen(component: SettingsComponent) {
     }
 
     Column(
-        modifier = Modifier.fillMaxSize()
+        modifier = Modifier.fillMaxSize().verticalScroll(rememberScrollState())
     ) {
         Text(
             modifier = Modifier.align(Alignment.CenterHorizontally)
@@ -77,6 +80,22 @@ fun SettingsScreen(component: SettingsComponent) {
             Row {
                 Text(
                     modifier = Modifier.padding(bottom = 16.dp),
+                    text = stringResource(Res.string.profile),
+                    color = MaterialTheme.colorScheme.primary,
+                    style = MaterialTheme.typography.titleSmall
+                )
+            }
+            Row {
+                SettingsCard(
+                    icon = Res.drawable.ic_expense_tags,
+                    title = Res.string.profile,
+                    description = Res.string.profile,
+                    onClick = component.onNavigateToProfile,
+                )
+            }
+            Row {
+                Text(
+                    modifier = Modifier.padding(top = 24.dp, bottom = 16.dp),
                     text = stringResource(Res.string.expense_tags_title),
                     color = MaterialTheme.colorScheme.primary,
                     style = MaterialTheme.typography.titleSmall

--- a/composeApp/src/iosMain/kotlin/com/banko/app/MainViewController.kt
+++ b/composeApp/src/iosMain/kotlin/com/banko/app/MainViewController.kt
@@ -4,16 +4,31 @@ import androidx.compose.runtime.remember
 import androidx.compose.ui.window.ComposeUIViewController
 import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.essenty.lifecycle.LifecycleRegistry
+import com.banko.app.api.auth.SessionManager
 import com.banko.app.di.initKoin
+import com.banko.app.ui.screens.auth.AuthComponent
 import com.banko.app.ui.screens.navigation.RootComponent
+import org.koin.compose.koinInject
 
 fun MainViewController() = ComposeUIViewController(
     configure = {
         initKoin()
     }
 ) {
-    val root = remember { RootComponent(DefaultComponentContext(LifecycleRegistry())) }
+    val sessionManager = koinInject<SessionManager>()
+    val root = remember {
+        RootComponent(
+            componentContext = DefaultComponentContext(LifecycleRegistry()),
+            sessionManager = sessionManager,
+        )
+    }
+    val authComponent = remember {
+        AuthComponent(
+            componentContext = DefaultComponentContext(LifecycleRegistry()),
+        )
+    }
     App(
         root = root,
+        authComponent = authComponent,
     )
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ ktor = "3.0.2"
 ksp = "2.1.0-1.0.29"
 material = "1.7.0"
 mockk = "1.13.14"
+multiplatformSettings = "1.2.0"
 robolectric = "4.14.1"
 room = "2.7.0-alpha12"
 serialization = "1.7.3"
@@ -80,6 +81,10 @@ ktor-client-mock = { group = "io.ktor", name = "ktor-client-mock", version.ref =
 # Navigation
 decompose = { group = "com.arkivanov.decompose", name = "decompose", version.ref = "decompose" }
 decompose-extensions = { group = "com.arkivanov.decompose", name = "extensions-compose-jetbrains", version.ref = "decompose" }
+
+# Multiplatform Settings
+multiplatform-settings-core = { module = "com.russhwolf:multiplatform-settings", version.ref = "multiplatformSettings" }
+multiplatform-settings-no-arg = { module = "com.russhwolf:multiplatform-settings-no-arg", version.ref = "multiplatformSettings" }
 
 # Room
 room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }


### PR DESCRIPTION
## What

* Add profile screen with account ID display, logout confirmation dialog, and wire auth-gated routing across the whole stack (RootComponent → SettingsScreen → ProfileScreen, iOS MainViewController)
* Add dev credential bypass in AuthRepository.login() that returns fake tokens without calling the API
* Add password visibility toggle on Login and Register screens using eye/eye-off icons

## Why

* Users need a place to see their account ID and log out; the iOS entry point also needed updating to support the auth flow
* Enable UI development and navigation testing without a running backend; remove before production
* Improve login UX by letting users verify their password before submitting
