### PR TITLE
Navigation duplicate configs

### DIFF
--- a/composeApp/src/androidUnitTest/kotlin/com/banko/app/api/auth/AuthRepositoryTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/banko/app/api/auth/AuthRepositoryTest.kt
@@ -22,7 +22,10 @@ class AuthRepositoryTest {
     private val apiService = mockk<BankoApiService>()
     private val tokenStorage = mockk<TokenStorage>(relaxed = true)
 
-    private fun createRepository(): AuthRepository = AuthRepository(apiService, tokenStorage)
+    private fun createRepository(): AuthRepository {
+        every { apiService.clearAuthCache() } just runs
+        return AuthRepository(apiService, tokenStorage)
+    }
 
     @Test
     fun `login success stores tokens`() {

--- a/composeApp/src/commonMain/kotlin/com/banko/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/App.kt
@@ -18,6 +18,7 @@ import com.arkivanov.decompose.extensions.compose.jetbrains.stack.animation.slid
 import com.arkivanov.decompose.extensions.compose.jetbrains.stack.animation.stackAnimation
 import com.arkivanov.decompose.extensions.compose.jetbrains.subscribeAsState
 import com.arkivanov.decompose.router.stack.popTo
+import com.arkivanov.decompose.router.stack.bringToFront
 import com.arkivanov.decompose.router.stack.pushNew
 import com.banko.app.api.auth.AuthState
 import com.banko.app.ui.screens.auth.AuthComponent
@@ -68,7 +69,7 @@ fun App(root: RootComponent, authComponent: AuthComponent) {
                                     onClick = {
                                         if (childStack.value.active.configuration != item.route) {
                                             if (item.route != RootComponent.Configuration.Home) {
-                                                root.navigation.pushNew(item.route)
+                                                root.navigation.bringToFront(item.route)
                                             } else {
                                                 root.navigation.popTo(index = 0)
                                             }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/api/auth/AuthRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/api/auth/AuthRepository.kt
@@ -22,6 +22,7 @@ class AuthRepository(
             tokenStorage.accessToken = devResponse.accessToken
             tokenStorage.refreshToken = devResponse.refreshToken
             tokenStorage.accountId = devResponse.accountId
+            apiService.clearAuthCache()
             return Result.Success(devResponse)
         }
         return when (val result = apiService.login(email, password)) {
@@ -29,6 +30,7 @@ class AuthRepository(
                 tokenStorage.accessToken = result.value.accessToken
                 tokenStorage.refreshToken = result.value.refreshToken
                 tokenStorage.accountId = result.value.accountId
+                apiService.clearAuthCache()
                 result
             }
             is Result.Error -> result
@@ -46,6 +48,7 @@ class AuthRepository(
                 tokenStorage.accessToken = result.value.accessToken
                 tokenStorage.refreshToken = result.value.refreshToken
                 tokenStorage.accountId = result.value.accountId
+                apiService.clearAuthCache()
                 result
             }
             is Result.Error -> result
@@ -59,6 +62,7 @@ class AuthRepository(
             is Result.Success -> {
                 tokenStorage.accessToken = result.value.accessToken
                 tokenStorage.refreshToken = result.value.refreshToken
+                apiService.clearAuthCache()
                 result
             }
             is Result.Error -> {

--- a/composeApp/src/commonMain/kotlin/com/banko/app/api/services/BankoApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/api/services/BankoApiService.kt
@@ -21,10 +21,15 @@ import com.banko.app.api.utils.putSafe
 import com.banko.app.api.utils.deleteSafe
 import com.banko.app.api.utils.Result
 import io.ktor.client.HttpClient
+import io.ktor.client.call.body
+import io.ktor.client.plugins.ClientRequestException
 import io.ktor.client.plugins.auth.Auth
+import io.ktor.client.plugins.auth.authProvider
+import io.ktor.client.plugins.auth.providers.BearerAuthProvider
 import io.ktor.client.plugins.auth.providers.BearerTokens
 import io.ktor.client.plugins.auth.providers.bearer
 import io.ktor.client.request.parameter
+import io.ktor.client.request.post
 import io.ktor.client.request.setBody
 import io.ktor.http.ContentType
 import io.ktor.http.contentType
@@ -46,10 +51,31 @@ class BankoApiService(
                         val refresh = ts.refreshToken ?: ""
                         BearerTokens(access, refresh)
                     }
+                    refreshTokens {
+                        val currentRefreshToken = ts.refreshToken
+                            ?: return@refreshTokens null
+                        try {
+                            val response = client.post("$baseUrl/Users/refresh") {
+                                contentType(ContentType.Application.Json)
+                                setBody(RefreshRequest(refreshToken = currentRefreshToken))
+                                markAsRefreshTokenRequest()
+                            }
+                            val authResponse = response.body<AuthResponse>()
+                            ts.accessToken = authResponse.accessToken
+                            ts.refreshToken = authResponse.refreshToken
+                            BearerTokens(authResponse.accessToken, authResponse.refreshToken)
+                        } catch (e: ClientRequestException) {
+                            null
+                        }
+                    }
                 }
             }
         }
     } ?: client
+
+    fun clearAuthCache() {
+        client.authProvider<BearerAuthProvider>()?.clearToken()
+    }
 
     private val baseUrl = "https://www.bankoapi.space"
 

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/navigation/RootComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/navigation/RootComponent.kt
@@ -3,9 +3,9 @@ package com.banko.app.ui.screens.navigation
 import com.arkivanov.decompose.ComponentContext
 import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.decompose.router.stack.StackNavigation
+import com.arkivanov.decompose.router.stack.bringToFront
 import com.arkivanov.decompose.router.stack.childStack
 import com.arkivanov.decompose.router.stack.pop
-import com.arkivanov.decompose.router.stack.pushNew
 import com.banko.app.api.auth.SessionManager
 import com.banko.app.ui.models.Transaction
 import com.banko.app.ui.screens.details.DetailsComponent
@@ -38,7 +38,7 @@ class RootComponent(
                 HomeComponent(
                     componentContext = context,
                     onNavigateToDetails = { transaction ->
-                        navigation.pushNew(Configuration.Details(transaction))
+                        navigation.bringToFront(Configuration.Details(transaction))
                     }
                 )
             )
@@ -53,7 +53,7 @@ class RootComponent(
             is Configuration.Settings -> Child.Settings(
                 SettingsComponent(
                     componentContext = context,
-                    onNavigateToProfile = { navigation.pushNew(Configuration.Profile) },
+                    onNavigateToProfile = { navigation.bringToFront(Configuration.Profile) },
                 )
             )
             is Configuration.Profile -> Child.Profile(


### PR DESCRIPTION
## What

* Implement `refreshTokens` callback in `BankoApiService` that calls `/Users/refresh` and stores the new token pair
* Clear Ktor's auth cache after login, register, and token refresh to prevent stale null-token 401s
* Replace `pushNew` with `bringToFront` in the bottom bar handler in `App.kt`
* Replace `pushNew` with `bringToFront` for internal Profile and Details navigation in `RootComponent.kt`

## Why

* Ktor 3.0.2's `BearerAuthProvider` requires an explicit `refreshTokens` block to refresh expired access tokens via the API's refresh endpoint
* Without clearing the auth cache after storing new credentials, Ktor's cached null token causes 401 errors on all subsequent authenticated requests
* Decompose 2.2.0's `pushNew` only checks the top of the stack — when the target config already exists lower in the stack it creates a duplicate, causing a crash; `bringToFront` removes existing instances before adding to the top, matching the correct UX
* The same duplicate-config crash occurs internally when re-navigating to Profile or Details screens that already exist in the back stack