### PR TITLE
fix: handle refresh token expiry gracefully

### DIFF
--- a/composeApp/src/androidUnitTest/kotlin/com/banko/app/api/auth/AuthRepositoryTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/banko/app/api/auth/AuthRepositoryTest.kt
@@ -19,7 +19,7 @@ import kotlin.test.assertTrue
 
 class AuthRepositoryTest {
 
-    private val apiService = mockk<BankoApiService>()
+    private val apiService = mockk<BankoApiService>(relaxed = true)
     private val tokenStorage = mockk<TokenStorage>(relaxed = true)
 
     private fun createRepository(): AuthRepository {

--- a/composeApp/src/androidUnitTest/kotlin/com/banko/app/api/auth/SessionManagerTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/banko/app/api/auth/SessionManagerTest.kt
@@ -37,12 +37,29 @@ class SessionManagerTest {
     }
 
     @Test
-    fun `init authenticated when logged in`() {
+    fun `init authenticated when logged in and refresh succeeds`() = runTest(testDispatcher) {
         every { authRepository.isLoggedIn } returns true
+        coEvery { authRepository.refreshToken() } returns Result.Success(
+            AuthResponse("acc-1", "tok", "ref", 900)
+        )
 
         val sessionManager = SessionManager(authRepository)
+        advanceUntilIdle()
 
         assertEquals(AuthState.Authenticated, sessionManager.authState.value)
+    }
+
+    @Test
+    fun `init unauthenticated when refresh fails`() = runTest(testDispatcher) {
+        every { authRepository.isLoggedIn } returns true
+        coEvery { authRepository.refreshToken() } returns Result.Error.HttpError(
+            401, "Unauthorized"
+        )
+
+        val sessionManager = SessionManager(authRepository)
+        advanceUntilIdle()
+
+        assertEquals(AuthState.Unauthenticated, sessionManager.authState.value)
     }
 
     @Test
@@ -97,9 +114,13 @@ class SessionManagerTest {
     }
 
     @Test
-    fun `logout transitions to unauthenticated`() {
+    fun `logout transitions to unauthenticated`() = runTest(testDispatcher) {
         every { authRepository.isLoggedIn } returns true
+        coEvery { authRepository.refreshToken() } returns Result.Success(
+            AuthResponse("acc-1", "tok", "ref", 900)
+        )
         val sessionManager = SessionManager(authRepository)
+        advanceUntilIdle()
 
         sessionManager.logout()
 

--- a/composeApp/src/commonMain/kotlin/com/banko/app/api/auth/AuthRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/api/auth/AuthRepository.kt
@@ -8,6 +8,10 @@ class AuthRepository(
     private val apiService: BankoApiService,
     private val tokenStorage: TokenStorage
 ) {
+    init {
+        apiService.onSessionExpired = { logout() }
+    }
+
     val isLoggedIn: Boolean
         get() = tokenStorage.accessToken != null
 
@@ -67,6 +71,7 @@ class AuthRepository(
             }
             is Result.Error -> {
                 tokenStorage.clear()
+                apiService.clearAuthCache()
                 result
             }
         }
@@ -74,5 +79,6 @@ class AuthRepository(
 
     fun logout() {
         tokenStorage.clear()
+        apiService.clearAuthCache()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/api/auth/SessionManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/api/auth/SessionManager.kt
@@ -23,10 +23,18 @@ class SessionManager(
     val authState: StateFlow<AuthState> = _authState.asStateFlow()
 
     init {
-        _authState.value = if (authRepository.isLoggedIn) {
-            AuthState.Authenticated
+        if (authRepository.isLoggedIn) {
+            scope.launch {
+                when (authRepository.refreshToken()) {
+                    is Result.Success -> _authState.value = AuthState.Authenticated
+                    is Result.Error -> {
+                        authRepository.logout()
+                        _authState.value = AuthState.Unauthenticated
+                    }
+                }
+            }
         } else {
-            AuthState.Unauthenticated
+            _authState.value = AuthState.Unauthenticated
         }
     }
 

--- a/composeApp/src/commonMain/kotlin/com/banko/app/api/services/BankoApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/api/services/BankoApiService.kt
@@ -22,7 +22,6 @@ import com.banko.app.api.utils.deleteSafe
 import com.banko.app.api.utils.Result
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
-import io.ktor.client.plugins.ClientRequestException
 import io.ktor.client.plugins.auth.Auth
 import io.ktor.client.plugins.auth.authProvider
 import io.ktor.client.plugins.auth.providers.BearerAuthProvider
@@ -41,6 +40,8 @@ class BankoApiService(
     client: HttpClient = HttpClient(HttpClientProvider()),
     private val tokenStorage: TokenStorage? = null
 ) {
+    var onSessionExpired: (() -> Unit)? = null
+
     private val client = tokenStorage?.let { ts ->
         HttpClient {
             HttpClientProvider()()
@@ -64,7 +65,8 @@ class BankoApiService(
                             ts.accessToken = authResponse.accessToken
                             ts.refreshToken = authResponse.refreshToken
                             BearerTokens(authResponse.accessToken, authResponse.refreshToken)
-                        } catch (e: ClientRequestException) {
+                        } catch (e: Exception) {
+                            onSessionExpired?.invoke()
                             null
                         }
                     }


### PR DESCRIPTION
## What

- Add silent token refresh on app startup with loading state
- Propagate session expiry to UI when refresh token is invalid
- Wire auth cache clearing on logout and refresh failure
- Catch broad exceptions instead of only ClientRequestException in Ktor refresh interceptor

## Why

- Previously the app declared itself authenticated based solely on token existence, causing a blank broken state when tokens had expired
- Without expiry propagation, users got stuck on the main screen with failing API calls instead of being redirected to login
- Missing cache clearing could leave stale Ktor auth state after logout or token rotation
- Unhandled exceptions (non-4xx) during token refresh would crash the request silently
