### PR TITLE
Feature/transactionlist restyle

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -72,6 +72,8 @@ kotlin {
             implementation(libs.room.runtime)
             implementation(libs.room.paging)
             implementation(libs.sqlite.bundle)
+            implementation(libs.coil.compose)
+            implementation(libs.coil.network.ktor)
 
             api(libs.datastore)
             api(libs.datastore.preferences)

--- a/composeApp/schemas/com.banko.app.database.BankoDatabase/6.json
+++ b/composeApp/schemas/com.banko.app.database.BankoDatabase/6.json
@@ -1,0 +1,297 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 6,
+    "identityHash": "a93f44d5f12438885dc0163b2f5283dc",
+    "entities": [
+      {
+        "tableName": "transactions",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `bookingDate` TEXT NOT NULL, `valueDate` TEXT NOT NULL, `amount` TEXT NOT NULL, `currency` TEXT NOT NULL, `debtorAccountId` TEXT, `remittanceInformationUnstructured` TEXT NOT NULL, `remittanceInformationUnstructuredArray` TEXT NOT NULL, `bankTransactionCode` TEXT NOT NULL, `internalTransactionId` TEXT NOT NULL, `creditorName` TEXT, `creditorAccountId` TEXT, `debtorName` TEXT, `remittanceInformationStructuredArray` TEXT, `note` TEXT, `expenseTagId` TEXT, `bankName` TEXT, `bankLogoUrl` TEXT, PRIMARY KEY(`id`), FOREIGN KEY(`expenseTagId`) REFERENCES `expense_tag`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL , FOREIGN KEY(`creditorAccountId`) REFERENCES `creditor_account`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL , FOREIGN KEY(`debtorAccountId`) REFERENCES `debtor_account`(`id`) ON UPDATE NO ACTION ON DELETE SET NULL )",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookingDate",
+            "columnName": "bookingDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "valueDate",
+            "columnName": "valueDate",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "amount",
+            "columnName": "amount",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "currency",
+            "columnName": "currency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "debtorAccountId",
+            "columnName": "debtorAccountId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remittanceInformationUnstructured",
+            "columnName": "remittanceInformationUnstructured",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "remittanceInformationUnstructuredArray",
+            "columnName": "remittanceInformationUnstructuredArray",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bankTransactionCode",
+            "columnName": "bankTransactionCode",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "internalTransactionId",
+            "columnName": "internalTransactionId",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "creditorName",
+            "columnName": "creditorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "creditorAccountId",
+            "columnName": "creditorAccountId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "debtorName",
+            "columnName": "debtorName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "remittanceInformationStructuredArray",
+            "columnName": "remittanceInformationStructuredArray",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "note",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "expenseTagId",
+            "columnName": "expenseTagId",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bankName",
+            "columnName": "bankName",
+            "affinity": "TEXT"
+          },
+          {
+            "fieldPath": "bankLogoUrl",
+            "columnName": "bankLogoUrl",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        },
+        "foreignKeys": [
+          {
+            "table": "expense_tag",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "expenseTagId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "creditor_account",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "creditorAccountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          },
+          {
+            "table": "debtor_account",
+            "onDelete": "SET NULL",
+            "onUpdate": "NO ACTION",
+            "columns": [
+              "debtorAccountId"
+            ],
+            "referencedColumns": [
+              "id"
+            ]
+          }
+        ]
+      },
+      {
+        "tableName": "expense_tag",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `name` TEXT NOT NULL, `color` INTEGER NOT NULL, `isEarning` INTEGER DEFAULT 0, `aka` TEXT, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "name",
+            "columnName": "name",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "color",
+            "columnName": "color",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isEarning",
+            "columnName": "isEarning",
+            "affinity": "INTEGER",
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "aka",
+            "columnName": "aka",
+            "affinity": "TEXT"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "creditor_account",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `iban` TEXT NOT NULL, `bban` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iban",
+            "columnName": "iban",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bban",
+            "columnName": "bban",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "debtor_account",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`id` TEXT NOT NULL, `iban` TEXT NOT NULL, `bban` TEXT NOT NULL, PRIMARY KEY(`id`))",
+        "fields": [
+          {
+            "fieldPath": "id",
+            "columnName": "id",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "iban",
+            "columnName": "iban",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bban",
+            "columnName": "bban",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "id"
+          ]
+        }
+      },
+      {
+        "tableName": "exchange_rates",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`fromCurrency` TEXT NOT NULL, `toCurrency` TEXT NOT NULL, `date` TEXT NOT NULL, `rate` REAL, PRIMARY KEY(`fromCurrency`, `toCurrency`, `date`))",
+        "fields": [
+          {
+            "fieldPath": "fromCurrency",
+            "columnName": "fromCurrency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "toCurrency",
+            "columnName": "toCurrency",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "date",
+            "columnName": "date",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "rate",
+            "columnName": "rate",
+            "affinity": "REAL"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": false,
+          "columnNames": [
+            "fromCurrency",
+            "toCurrency",
+            "date"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, 'a93f44d5f12438885dc0163b2f5283dc')"
+    ]
+  }
+}

--- a/composeApp/src/androidUnitTest/kotlin/com/banko/app/domain/AssignExpenseTagToTransactionUseCaseTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/banko/app/domain/AssignExpenseTagToTransactionUseCaseTest.kt
@@ -89,4 +89,45 @@ class AssignExpenseTagToTransactionUseCaseTest {
         }
         Unit
     }
+
+    @Test
+    fun `should clear expense tag when expenseTagId is null`() = runBlocking {
+        val transactionId = "tx-1"
+        val transaction = Transaction(
+            id = transactionId,
+            bookingDate = "2024-01-15",
+            valueDate = "2024-01-15",
+            amount = "42.50",
+            currency = "EUR",
+            debtorAccountId = null,
+            remittanceInformationUnstructured = "Test payment",
+            remittanceInformationUnstructuredArray = emptyList(),
+            bankTransactionCode = "PMNT",
+            internalTransactionId = "int-1",
+            creditorName = null,
+            creditorAccountId = null,
+            debtorName = null,
+            remittanceInformationStructuredArray = null,
+            note = null,
+            expenseTagId = "old-tag"
+        )
+
+        coEvery { transactionRepository.findRawTransactionById(transactionId) } returns transaction
+        coEvery { transactionRepository.upsertTransaction(any(), any(), any(), any()) } returns Unit
+
+        useCase(transactionId, null)
+
+        coVerify {
+            transactionRepository.findRawTransactionById(transactionId)
+            transactionRepository.upsertTransaction(
+                transaction = transaction.copy(expenseTagId = null),
+                creditorAccount = null,
+                debtorAccount = null,
+                expenseTag = null
+            )
+        }
+        coVerify(exactly = 0) {
+            expenseTagRepository.findExpenseTagById(any())
+        }
+    }
 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/api/auth/SessionManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/api/auth/SessionManager.kt
@@ -24,6 +24,7 @@ class SessionManager(
 
     init {
         if (authRepository.isLoggedIn) {
+            _authState.value = AuthState.Authenticated
             scope.launch {
                 when (authRepository.refreshToken()) {
                     is Result.Success -> _authState.value = AuthState.Authenticated

--- a/composeApp/src/commonMain/kotlin/com/banko/app/api/dto/bankoApi/Transactions.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/api/dto/bankoApi/Transactions.kt
@@ -33,7 +33,9 @@ data class Transaction(
     val debtorName: String? = null,
     val remittanceInformationStructuredArray: List<String>? = null,
     val note: String? = null,
-    val expenseTag: ExpenseTag? = null
+    val expenseTag: ExpenseTag? = null,
+    val bankName: String? = null,
+    val bankLogoUrl: String? = null
 )
 
 @Serializable
@@ -66,7 +68,9 @@ fun Transaction.toModelItem() = ModelTransaction(
     debtorName = debtorName,
     remittanceInformationStructuredArray = remittanceInformationStructuredArray,
     note = note,
-    expenseTag = expenseTag?.toModelItem()
+    expenseTag = expenseTag?.toModelItem(),
+    bankName = bankName,
+    bankLogoUrl = bankLogoUrl
 )
 
 fun DebtorAccount.toModelItem() = ModelDebtorAccount(

--- a/composeApp/src/commonMain/kotlin/com/banko/app/data/mapper/TransactionMappers.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/data/mapper/TransactionMappers.kt
@@ -31,7 +31,9 @@ fun FullTransaction.toDomain(): DomainTransaction = DomainTransaction(
     debtorName = transaction.debtorName,
     remittanceInformationStructuredArray = transaction.remittanceInformationStructuredArray,
     note = transaction.note,
-    expenseTag = expenseTag?.toDomain()
+    expenseTag = expenseTag?.toDomain(),
+    bankName = transaction.bankName,
+    bankLogoUrl = transaction.bankLogoUrl
 )
 
 fun List<FullTransaction>.toDomain(): List<DomainTransaction> = map { it.toDomain() }
@@ -62,7 +64,9 @@ fun DtoTransaction.toDomain(): DomainTransaction = DomainTransaction(
     debtorName = debtorName,
     remittanceInformationStructuredArray = remittanceInformationStructuredArray,
     note = note,
-    expenseTag = expenseTag?.toDomain()
+    expenseTag = expenseTag?.toDomain(),
+    bankName = bankName,
+    bankLogoUrl = bankLogoUrl
 )
 
 fun DtoCreditorAccount.toDomain() = DomainCreditorAccount(id = id, iban = iban, bban = bban)
@@ -91,7 +95,9 @@ fun DomainTransaction.toDao(): DaoTransaction = DaoTransaction(
     debtorName = debtorName,
     remittanceInformationStructuredArray = remittanceInformationStructuredArray,
     note = note,
-    expenseTagId = expenseTag?.id
+    expenseTagId = expenseTag?.id,
+    bankName = bankName,
+    bankLogoUrl = bankLogoUrl
 )
 
 fun DomainCreditorAccount.toDao() = DaoCreditorAccount(id = id, iban = iban, bban = bban)

--- a/composeApp/src/commonMain/kotlin/com/banko/app/database/BankoDatabase.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/database/BankoDatabase.kt
@@ -19,7 +19,7 @@ import com.banko.app.database.Entities.Transaction
         DebtorAccount::class,
         ExchangeRate::class,
     ],
-    version = 5,
+    version = 6,
     exportSchema = true
 )
 @ConstructedBy(BankoDatabaseConstructor::class)

--- a/composeApp/src/commonMain/kotlin/com/banko/app/database/Entities/FullTransaction.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/database/Entities/FullTransaction.kt
@@ -31,5 +31,7 @@ fun FullTransaction.toModelItem() = ModelTransaction(
     debtorName = transaction.debtorName,
     remittanceInformationStructuredArray = transaction.remittanceInformationStructuredArray,
     note = transaction.note,
-    expenseTag = expenseTag?.toModelItem()
+    expenseTag = expenseTag?.toModelItem(),
+    bankName = transaction.bankName,
+    bankLogoUrl = transaction.bankLogoUrl
 )

--- a/composeApp/src/commonMain/kotlin/com/banko/app/database/Entities/Transaction.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/database/Entities/Transaction.kt
@@ -44,5 +44,7 @@ data class Transaction(
     val debtorName: String?,
     val remittanceInformationStructuredArray: List<String>?,
     val note: String?,
-    val expenseTagId: String?
+    val expenseTagId: String?,
+    val bankName: String? = null,
+    val bankLogoUrl: String? = null
 )

--- a/composeApp/src/commonMain/kotlin/com/banko/app/domain/AssignExpenseTagToTransactionUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/domain/AssignExpenseTagToTransactionUseCase.kt
@@ -13,6 +13,13 @@ class AssignExpenseTagToTransactionUseCase(
     suspend operator fun invoke(transactionId: String, expenseTagId: String?) {
         val transaction = transactionRepository.findRawTransactionById(transactionId)
             ?: error("no transaction in db with id $transactionId")
+        if (expenseTagId == null) {
+            transactionRepository.upsertTransaction(
+                transaction = transaction.copy(expenseTagId = null),
+                expenseTag = null
+            )
+            return
+        }
         val tag = expenseTagRepository.findExpenseTagById(expenseTagId).first()
             ?: error("no expense tag found in db with id $expenseTagId")
         transactionRepository.upsertTransaction(

--- a/composeApp/src/commonMain/kotlin/com/banko/app/domain/model/Transaction.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/domain/model/Transaction.kt
@@ -18,7 +18,9 @@ data class Transaction(
     val debtorName: String? = null,
     val remittanceInformationStructuredArray: List<String>? = null,
     val note: String? = null,
-    val expenseTag: ExpenseTag? = null
+    val expenseTag: ExpenseTag? = null,
+    val bankName: String? = null,
+    val bankLogoUrl: String? = null
 )
 
 data class CreditorAccount(

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/BankLogo.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/BankLogo.kt
@@ -1,0 +1,77 @@
+package com.banko.app.ui.components
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import banko.composeapp.generated.resources.Res
+import banko.composeapp.generated.resources.account_balance
+import coil3.compose.AsyncImage
+import org.jetbrains.compose.resources.painterResource
+
+@Composable
+fun BankLogo(
+    logoUrl: String?,
+    bankName: String?,
+    modifier: Modifier = Modifier,
+    size: Int = 22
+) {
+    val sizeDp = size.dp
+
+    if (!logoUrl.isNullOrBlank()) {
+        AsyncImage(
+            model = logoUrl,
+            contentDescription = bankName,
+            modifier = modifier
+                .size(sizeDp)
+                .clip(CircleShape)
+        )
+    } else if (!bankName.isNullOrBlank()) {
+        val initial = bankName.first().uppercase()
+        val color = bankNameToColor(bankName)
+        Box(
+            modifier = modifier
+                .size(sizeDp)
+                .clip(CircleShape)
+                .background(color),
+            contentAlignment = Alignment.Center
+        ) {
+            Text(
+                text = initial,
+                color = Color.White,
+                fontSize = (size * 0.5).sp,
+                textAlign = TextAlign.Center
+            )
+        }
+    } else {
+        Box(
+            modifier = modifier
+                .size(sizeDp)
+                .clip(CircleShape)
+                .background(MaterialTheme.colorScheme.surfaceVariant),
+            contentAlignment = Alignment.Center
+        ) {
+            androidx.compose.foundation.Image(
+                painter = painterResource(Res.drawable.account_balance),
+                contentDescription = null,
+                modifier = Modifier.size((size * 0.55).dp)
+            )
+        }
+    }
+}
+
+private fun bankNameToColor(name: String): Color {
+    val hash = name.hashCode()
+    val hue = ((hash and 0xFFFFFF).toFloat() % 360f + 360f) % 360f
+    return Color.hsl(hue, saturation = 0.55f, lightness = 0.45f)
+}

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/models/Transactions.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/models/Transactions.kt
@@ -28,7 +28,9 @@ data class Transaction (
     val debtorName: String? = null,
     val remittanceInformationStructuredArray: List<String>? = null,
     val note: String? = null,
-    val expenseTag: ExpenseTag? = null
+    val expenseTag: ExpenseTag? = null,
+    val bankName: String? = null,
+    val bankLogoUrl: String? = null
 )
 
 @Serializable
@@ -61,7 +63,9 @@ fun Transaction.toDao() = DaoTransaction(
     debtorName = debtorName,
     remittanceInformationStructuredArray = remittanceInformationStructuredArray,
     note = note,
-    expenseTagId = expenseTag?.id
+    expenseTagId = expenseTag?.id,
+    bankName = bankName,
+    bankLogoUrl = bankLogoUrl
 )
 
 fun DebtorAccount.toDao() = DaoDebtorAccount(
@@ -92,7 +96,9 @@ fun DomainTransaction.toUi() = Transaction(
     debtorName = debtorName,
     remittanceInformationStructuredArray = remittanceInformationStructuredArray,
     note = note,
-    expenseTag = expenseTag?.toUi()
+    expenseTag = expenseTag?.toUi(),
+    bankName = bankName,
+    bankLogoUrl = bankLogoUrl
 )
 
 fun DomainCreditorAccount.toUi() = CreditorAccount(id = id, iban = iban, bban = bban)

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/details/DetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/details/DetailsScreen.kt
@@ -60,6 +60,7 @@ import banko.composeapp.generated.resources.ic_quill
 import banko.composeapp.generated.resources.ic_save
 import banko.composeapp.generated.resources.ic_tag
 import banko.composeapp.generated.resources.ic_tag_filled
+import com.banko.app.ui.components.BankLogo
 import com.banko.app.ui.components.ErrorSnackbarHost
 import com.banko.app.ui.models.ExpenseTag
 import com.banko.app.ui.models.Transaction
@@ -248,6 +249,36 @@ fun DetailsScreen(
             modifier = Modifier.fillMaxWidth().weight(1f)
                 .padding(top = 8.dp, start = 16.dp, end = 16.dp, bottom = 8.dp)
         ) {
+            // Bank Info
+            if (transaction.bankName != null) {
+                item {
+                    Row(
+                        modifier = Modifier.padding(start = 16.dp, end = 16.dp).fillMaxWidth(),
+                        verticalAlignment = Alignment.CenterVertically
+                    ) {
+                        BankLogo(
+                            logoUrl = transaction.bankLogoUrl,
+                            bankName = transaction.bankName
+                        )
+                        TextField(
+                            modifier = Modifier.weight(1f).padding(start = 12.dp),
+                            onValueChange = {},
+                            value = transaction.bankName ?: "",
+                            supportingText = {
+                                Text(text = "Bank")
+                            },
+                            readOnly = true,
+                            colors = TextFieldDefaults.colors(
+                                unfocusedTextColor = MaterialTheme.colorScheme.primary,
+                                focusedTextColor = MaterialTheme.colorScheme.primary,
+                                unfocusedContainerColor = MaterialTheme.colorScheme.surface,
+                                focusedContainerColor = MaterialTheme.colorScheme.surface,
+                            )
+                        )
+                    }
+                }
+            }
+
             // Remittance Information
             item {
                 TextField(

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreen.kt
@@ -88,6 +88,7 @@ import banko.composeapp.generated.resources.Res
 import banko.composeapp.generated.resources.app_name
 import banko.composeapp.generated.resources.details
 import banko.composeapp.generated.resources.ic_delete
+import banko.composeapp.generated.resources.ic_tag
 import banko.composeapp.generated.resources.ic_tag_filled
 import com.banko.app.ModelTransaction
 import com.banko.app.ui.components.BankLogo
@@ -528,15 +529,16 @@ private fun SwipableTransactionRow(
                     modifier = Modifier.fillMaxWidth(),
                     verticalAlignment = Alignment.CenterVertically
                 ) {
-                    if (transaction.expenseTag != null) {
-                        Icon(
-                            painter = painterResource(Res.drawable.ic_tag_filled),
-                            contentDescription = transaction.expenseTag.name,
-                            tint = transaction.expenseTag.color,
-                            modifier = Modifier.size(14.dp)
-                        )
-                        Spacer(modifier = Modifier.width(4.dp))
-                    }
+                    val tag = transaction.expenseTag
+                    Icon(
+                        painter = painterResource(
+                            if (tag != null) Res.drawable.ic_tag_filled else Res.drawable.ic_tag
+                        ),
+                        contentDescription = tag?.name,
+                        tint = tag?.color ?: MaterialTheme.colorScheme.primary,
+                        modifier = Modifier.size(14.dp)
+                    )
+                    Spacer(modifier = Modifier.width(4.dp))
                     Spacer(modifier = Modifier.weight(1f))
                     Text(
                         text = "${transaction.amount} ${currencyDisplayForCode(transaction.currency)}",

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreen.kt
@@ -27,6 +27,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -40,6 +41,8 @@ import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.lazy.LazyListState
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -85,7 +88,9 @@ import banko.composeapp.generated.resources.Res
 import banko.composeapp.generated.resources.app_name
 import banko.composeapp.generated.resources.details
 import banko.composeapp.generated.resources.ic_delete
+import banko.composeapp.generated.resources.ic_tag_filled
 import com.banko.app.ModelTransaction
+import com.banko.app.ui.components.BankLogo
 import com.banko.app.ui.components.CircularIndicator
 import com.banko.app.ui.components.ErrorSnackbarHost
 import com.banko.app.ui.components.ExpenseTag
@@ -458,8 +463,8 @@ private fun SwipableTransactionRow(
             )
         }
 
-        // Main Transaction Row
-        Row(
+        // Main Transaction Card
+        Card(
             modifier = Modifier
                 .fillMaxWidth()
                 .offset { IntOffset(offsetX.roundToInt(), 0) }
@@ -487,44 +492,60 @@ private fun SwipableTransactionRow(
                             }
                         }
                     )
+                },
+            shape = RoundedCornerShape(12.dp),
+            colors = CardDefaults.cardColors(
+                containerColor = MaterialTheme.colorScheme.surface
+            ),
+            elevation = CardDefaults.cardElevation(defaultElevation = 2.dp)
+        ) {
+            Column(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 12.dp, vertical = 8.dp)
+            ) {
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    Text(
+                        modifier = Modifier.weight(1f),
+                        text = transaction.remittanceInformationUnstructured.replace("\\s+".toRegex(), " "),
+                        color = MaterialTheme.colorScheme.primary,
+                        overflow = TextOverflow.Ellipsis,
+                        maxLines = 1,
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                    Spacer(modifier = Modifier.width(8.dp))
+                    BankLogo(
+                        logoUrl = transaction.bankLogoUrl,
+                        bankName = transaction.bankName,
+                        size = 22
+                    )
                 }
-                .background(MaterialTheme.colorScheme.surface)
-                .padding(horizontal = 8.dp, vertical = 4.dp)
-        )
-        {
-            Column(
-                modifier = Modifier
-                    .weight(7f)
-                    .align(Alignment.CenterVertically)
-                    .padding(start = 12.dp, end = 7.dp)
-            ) {
-                Text(
-                    text = transaction.remittanceInformationUnstructured,
-                    color = MaterialTheme.colorScheme.primary,
-                    overflow = TextOverflow.Ellipsis,
-                    maxLines = 1
-                )
-            }
-            Column(
-                modifier = Modifier
-                    .weight(3f)
-                    .align(Alignment.CenterVertically)
-                    .padding(end = 5.dp)
-            ) {
-                Text(
-                    modifier = Modifier.align(Alignment.End),
-                    text = "${transaction.amount} ${currencyDisplayForCode(transaction.currency)}",
-                    color = MaterialTheme.colorScheme.primary,
-                    overflow = TextOverflow.Ellipsis,
-                    maxLines = 1
-                )
-            }
-            Column(
-                modifier = Modifier
-                    .weight(1f)
-                    .align(Alignment.CenterVertically)
-            ) {
-                ExpenseTag(transaction.expenseTag)
+                Spacer(modifier = Modifier.height(4.dp))
+                Row(
+                    modifier = Modifier.fillMaxWidth(),
+                    verticalAlignment = Alignment.CenterVertically
+                ) {
+                    if (transaction.expenseTag != null) {
+                        Icon(
+                            painter = painterResource(Res.drawable.ic_tag_filled),
+                            contentDescription = transaction.expenseTag.name,
+                            tint = transaction.expenseTag.color,
+                            modifier = Modifier.size(14.dp)
+                        )
+                        Spacer(modifier = Modifier.width(4.dp))
+                    }
+                    Spacer(modifier = Modifier.weight(1f))
+                    Text(
+                        text = "${transaction.amount} ${currencyDisplayForCode(transaction.currency)}",
+                        color = if (transaction.amount >= 0) MaterialTheme.colorScheme.primary else MaterialTheme.colorScheme.error,
+                        overflow = TextOverflow.Ellipsis,
+                        maxLines = 1,
+                        style = MaterialTheme.typography.bodySmall
+                    )
+                }
             }
         }
     }

--- a/composeApp/src/commonTest/kotlin/com/banko/app/data/mapper/TransactionMappersTest.kt
+++ b/composeApp/src/commonTest/kotlin/com/banko/app/data/mapper/TransactionMappersTest.kt
@@ -36,7 +36,9 @@ class TransactionMappersTest {
         debtorName = "John Doe",
         remittanceInformationStructuredArray = listOf("INV-001"),
         note = "Test note",
-        expenseTag = DomainExpenseTag(id = "tag-1", name = "Groceries", color = 0xFF00FF, isEarning = false, aka = listOf("food"))
+        expenseTag = DomainExpenseTag(id = "tag-1", name = "Groceries", color = 0xFF00FF, isEarning = false, aka = listOf("food")),
+        bankName = "ING",
+        bankLogoUrl = "https://example.com/ing-logo.png"
     )
 
     private val daoCreditorAccount = DaoCreditorAccount(id = "cred-1", iban = "DE789", bban = "012")
@@ -61,7 +63,9 @@ class TransactionMappersTest {
         debtorName = "John Doe",
         remittanceInformationStructuredArray = listOf("INV-001"),
         note = "Test note",
-        expenseTag = DtoExpenseTag(id = "tag-1", name = "Groceries", color = 0xFF00FF, isEarning = false, aka = listOf("food"))
+        expenseTag = DtoExpenseTag(id = "tag-1", name = "Groceries", color = 0xFF00FF, isEarning = false, aka = listOf("food")),
+        bankName = "ING",
+        bankLogoUrl = "https://example.com/ing-logo.png"
     )
 
     @Test
@@ -213,7 +217,9 @@ class TransactionMappersTest {
             creditorName = null,
             debtorName = null,
             note = null,
-            remittanceInformationStructuredArray = null
+            remittanceInformationStructuredArray = null,
+            bankName = null,
+            bankLogoUrl = null
         )
         val result = dto.toDomain()
         val expected = domainTransaction.copy(
@@ -224,7 +230,9 @@ class TransactionMappersTest {
             creditorName = null,
             debtorName = null,
             note = null,
-            remittanceInformationStructuredArray = null
+            remittanceInformationStructuredArray = null,
+            bankName = null,
+            bankLogoUrl = null
         )
         assertEquals(expected, result)
     }
@@ -245,5 +253,38 @@ class TransactionMappersTest {
     fun `List of FullTransaction toDomain should return empty list for empty input`() {
         val result = emptyList<FullTransaction>().toDomain()
         assertEquals(emptyList(), result)
+    }
+
+    @Test
+    fun `FullTransaction toDomain should map bankName and bankLogoUrl`() {
+        val fullTx = FullTransaction(
+            transaction = daoTransaction,
+            creditorAccount = daoCreditorAccount,
+            debtorAccount = daoDebtorAccount,
+            expenseTag = daoExpenseTag
+        )
+        val result = fullTx.toDomain()
+        assertEquals("ING", result.bankName)
+        assertEquals("https://example.com/ing-logo.png", result.bankLogoUrl)
+    }
+
+    @Test
+    fun `FullTransaction toDomain should map null bankName and bankLogoUrl`() {
+        val fullTx = FullTransaction(
+            transaction = daoTransaction.copy(bankName = null, bankLogoUrl = null),
+            creditorAccount = daoCreditorAccount,
+            debtorAccount = daoDebtorAccount,
+            expenseTag = daoExpenseTag
+        )
+        val result = fullTx.toDomain()
+        assertNull(result.bankName)
+        assertNull(result.bankLogoUrl)
+    }
+
+    @Test
+    fun `DomainTransaction toDao should preserve bankName and bankLogoUrl`() {
+        val result = domainTransaction.toDao()
+        assertEquals("ING", result.bankName)
+        assertEquals("https://example.com/ing-logo.png", result.bankLogoUrl)
     }
 }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.10.1"
-android-compileSdk = "34"
+android-compileSdk = "36"
 android-minSdk = "25"
 android-targetSdk = "34"
 androidx-activityCompose = "1.9.3"
@@ -31,6 +31,7 @@ robolectric = "4.14.1"
 room = "2.7.0-alpha12"
 serialization = "1.7.3"
 sqllite = "2.5.0-alpha12"
+coil = "3.1.0"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -90,6 +91,10 @@ room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "
 room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }
 room-paging = { group = "androidx.room", name = "room-paging", version.ref = "room" }
 sqlite-bundle = { group = "androidx.sqlite", name = "sqlite-bundled", version.ref = "sqllite" }
+
+# Coil
+coil-compose = { module = "io.coil-kt.coil3:coil-compose", version.ref = "coil" }
+coil-network-ktor = { module = "io.coil-kt.coil3:coil-network-ktor3", version.ref = "coil" }
 
 # Serialization
 kotlinx-serialization-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-serialization-core", version.ref = "serialization" }


### PR DESCRIPTION
## What
- Add Coil 3 multiplatform image loading library for fetching bank logos from URLs
- Persist bankName and bankLogoUrl in Room database (new nullable columns, DB v5→6)
- Fix all data pipeline mappers to pass bank branding fields through (DTO→Domain→DAO→UI)
- Create reusable BankLogo composable with three states: network image, initial-colored circle, generic icon fallback
- Restyle transaction list rows as elevated cards with two-line layout: description + bank logo on top, tag icon + amount on bottom
- Add bank logo to transaction details screen alongside bank name field
- Fix AssignExpenseTagToTransactionUseCase crash when unassigning a tag (null expenseTagId)
- Skip loading screen on app open when a stored token exists; validate in background
- Show tag icon for all transactions: outline (primary) when unassigned, filled (tag color) when assigned
- Add test coverage for bank info mapping and null tag assignment
## Why
- Bank names and logos were returned by the API but silently dropped at every mapper layer — data was never persisted or displayed
- Transaction list rows were flat and lacked visual hierarchy; cards with bank branding make each transaction scannable at a glance
- The loading spinner on every app open was caused by blocking on a network refresh call before showing any UI — optimistic auth eliminates the delay
- Unassigning an expense tag crashed the app because the use case didn't handle null IDs
