### PR TITLE
feat: improve home screen navigation and details screen UX

### DIFF
--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/details/DetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/details/DetailsScreen.kt
@@ -1,6 +1,7 @@
 package com.banko.app.ui.screens.details
 
 import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
@@ -57,7 +58,6 @@ import banko.composeapp.generated.resources.ic_arrow_drop_down
 import banko.composeapp.generated.resources.ic_calendar_month
 import banko.composeapp.generated.resources.ic_more
 import banko.composeapp.generated.resources.ic_quill
-import banko.composeapp.generated.resources.ic_save
 import banko.composeapp.generated.resources.ic_tag
 import banko.composeapp.generated.resources.ic_tag_filled
 import com.banko.app.ui.components.BankLogo
@@ -537,8 +537,8 @@ fun DetailsScreen(
 
             // Expense Tag
             item {
-                Row(
-                    modifier = Modifier.fillMaxWidth()
+                Box(
+                    modifier = Modifier.fillMaxWidth().padding(top = 12.dp, start = 16.dp, end = 16.dp)
                 ) {
                     TextField(
                         modifier = Modifier.padding(top = 12.dp, start = 16.dp),
@@ -564,22 +564,11 @@ fun DetailsScreen(
                             )
                         },
                         trailingIcon = {
-                            IconButton(onClick = {
-                                getExpenseTags()
-                                tagMenuExpanded.value = true
-                            }, content = {
-                                Icon(
-                                    painter = painterResource(Res.drawable.ic_arrow_drop_down),
-                                    contentDescription = null,
-                                    tint = MaterialTheme.colorScheme.primary
-                                )
-                                ExpenseTagDropdown(
-                                    expanded = tagMenuExpanded,
-                                    expenseTags = expenseTags,
-                                    onTagSelected = { tag ->
-                                        transaction = transaction.copy(expenseTag = tag)
-                                    })
-                            })
+                            Icon(
+                                painter = painterResource(Res.drawable.ic_arrow_drop_down),
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary
+                            )
                         },
                         colors = TextFieldDefaults.colors(
                             unfocusedTextColor = MaterialTheme.colorScheme.primary,
@@ -588,21 +577,20 @@ fun DetailsScreen(
                             focusedContainerColor = MaterialTheme.colorScheme.surface,
                         )
                     )
-                    if (oldTag != transaction.expenseTag?.id) {
-                        IconButton(
-                            modifier = Modifier.align(Alignment.Bottom), onClick = {
-                                assignExpenseTag(
-                                    transaction.id, transaction.expenseTag?.id
-                                )
-                                oldTag = transaction.expenseTag?.id
-                            }) {
-                            Icon(
-                                painter = painterResource(Res.drawable.ic_save),
-                                contentDescription = null,
-                                tint = MaterialTheme.colorScheme.primary
-                            )
+                    Box(
+                        modifier = Modifier.matchParentSize().clickable {
+                            getExpenseTags()
+                            tagMenuExpanded.value = true
                         }
-                    }
+                    )
+                    ExpenseTagDropdown(
+                        expanded = tagMenuExpanded,
+                        expenseTags = expenseTags,
+                        onTagSelected = { tag ->
+                            transaction = transaction.copy(expenseTag = tag)
+                            assignExpenseTag(transaction.id, tag?.id)
+                            oldTag = tag?.id
+                        })
                 }
             }
 

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/details/DropDownMenus/ExpenseTagDropDown.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/details/DropDownMenus/ExpenseTagDropDown.kt
@@ -1,14 +1,29 @@
 package com.banko.app.ui.screens.details.DropDownMenus
 
 import androidx.compose.foundation.background
-import androidx.compose.material3.DropdownMenu
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.rememberScrollState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.DropdownMenuItem
+import androidx.compose.material3.ElevatedCard
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.Popup
 import banko.composeapp.generated.resources.Res
 import banko.composeapp.generated.resources.details_expense_tag_empty
 import banko.composeapp.generated.resources.ic_tag
@@ -23,44 +38,98 @@ internal fun ExpenseTagDropdown(
     expenseTags: List<ExpenseTag>,
     onTagSelected: (ExpenseTag?) -> Unit
 ) {
-    DropdownMenu(
-        modifier = Modifier.background(MaterialTheme.colorScheme.onSurface),
-        expanded = expanded.value,
+    if (!expanded.value) return
+
+    val maxVisibleItems = 7
+    val itemHeight = 48.dp
+    val surfaceColor = MaterialTheme.colorScheme.onSurface
+    val scrollState = rememberScrollState()
+
+    val totalItems = expenseTags.size + 1
+    val isScrollable = totalItems > maxVisibleItems
+    val canScrollUp = scrollState.value > 0
+    val canScrollDown = isScrollable && scrollState.value < scrollState.maxValue
+
+    Popup(
+        alignment = Alignment.TopEnd,
         onDismissRequest = { expanded.value = false }
     ) {
-        DropdownMenuItem(
-            leadingIcon = {
-                Icon(
-                    painter = painterResource(Res.drawable.ic_tag),
-                    contentDescription = null,
-                    tint = MaterialTheme.colorScheme.primary
-                )
-            },
-            text = {
-                Text(
-                    text = stringResource(Res.string.details_expense_tag_empty),
-                    color = MaterialTheme.colorScheme.primary
-                )
-            },
-            onClick = {
-                onTagSelected(null)
-                expanded.value = false
-            })
-        expenseTags.forEach { tag ->
-            DropdownMenuItem(leadingIcon = {
-                Icon(
-                    painter = painterResource(Res.drawable.ic_tag_filled),
-                    contentDescription = null,
-                    tint = tag.color
-                )
-            }, text = {
-                Text(
-                    text = tag.name, color = MaterialTheme.colorScheme.primary
-                )
-            }, onClick = {
-                onTagSelected(tag)
-                expanded.value = false
-            })
+        ElevatedCard(
+            shape = RoundedCornerShape(4.dp),
+            elevation = androidx.compose.material3.CardDefaults.elevatedCardElevation(defaultElevation = 4.dp),
+        ) {
+            Box(
+                modifier = Modifier.width(IntrinsicSize.Max)
+            ) {
+                Column(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .heightIn(max = itemHeight * maxVisibleItems)
+                        .verticalScroll(scrollState)
+                ) {
+                    DropdownMenuItem(
+                        leadingIcon = {
+                            Icon(
+                                painter = painterResource(Res.drawable.ic_tag),
+                                contentDescription = null,
+                                tint = MaterialTheme.colorScheme.primary
+                            )
+                        },
+                        text = {
+                            Text(
+                                text = stringResource(Res.string.details_expense_tag_empty),
+                                color = MaterialTheme.colorScheme.primary
+                            )
+                        },
+                        onClick = {
+                            onTagSelected(null)
+                            expanded.value = false
+                        })
+                    expenseTags.forEach { tag ->
+                        DropdownMenuItem(leadingIcon = {
+                            Icon(
+                                painter = painterResource(Res.drawable.ic_tag_filled),
+                                contentDescription = null,
+                                tint = tag.color
+                            )
+                        }, text = {
+                            Text(
+                                text = tag.name, color = MaterialTheme.colorScheme.primary
+                            )
+                        }, onClick = {
+                            onTagSelected(tag)
+                            expanded.value = false
+                        })
+                    }
+                }
+
+                if (canScrollUp) {
+                    Box(
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .height(24.dp)
+                            .background(
+                                Brush.verticalGradient(
+                                    colors = listOf(surfaceColor, surfaceColor.copy(alpha = 0f))
+                                )
+                            )
+                    )
+                }
+
+                if (canScrollDown) {
+                    Box(
+                        modifier = Modifier
+                            .align(Alignment.BottomCenter)
+                            .fillMaxWidth()
+                            .height(24.dp)
+                            .background(
+                                Brush.verticalGradient(
+                                    colors = listOf(surfaceColor.copy(alpha = 0f), surfaceColor)
+                                )
+                            )
+                    )
+                }
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/details/bottomsheets/EditNoteBottomSheet.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/details/bottomsheets/EditNoteBottomSheet.kt
@@ -25,6 +25,7 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.text.input.ImeAction
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.text.input.KeyboardType
 import androidx.compose.ui.unit.dp
 import banko.composeapp.generated.resources.Res
@@ -94,6 +95,7 @@ fun EditNoteBottomSheet(
             ),
             keyboardOptions = KeyboardOptions(
                 autoCorrectEnabled = true,
+                capitalization = KeyboardCapitalization.Sentences,
                 keyboardType = KeyboardType.Text,
                 imeAction = ImeAction.Send,
             )

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreen.kt
@@ -409,7 +409,7 @@ private fun SwipableTransactionRow(
     isOpen: Boolean,
     onOpen: () -> Unit,
     onClose: () -> Unit,
-    onDetailsClick: () -> Unit,
+    onClick: () -> Unit,
     onDeleteTransaction: (String) -> Unit
 ) {
     var offsetX by remember { mutableStateOf(0f) }
@@ -437,19 +437,6 @@ private fun SwipableTransactionRow(
             .fillMaxWidth()
             .background(MaterialTheme.colorScheme.surface)
     ) {
-        TextButton(
-            onClick = onDetailsClick,
-            modifier = Modifier.align(Alignment.CenterEnd)
-                .background(MaterialTheme.colorScheme.primary)
-                .width(85.dp)
-                .height(32.dp)
-        ) {
-            Text(
-                text = stringResource(Res.string.details),
-                color = MaterialTheme.colorScheme.onPrimary
-            )
-        }
-
         IconButton(
             onClick = { isDeleteTransaction.value = true },
             modifier = Modifier.align(Alignment.CenterStart)
@@ -474,17 +461,13 @@ private fun SwipableTransactionRow(
                         onHorizontalDrag = { change, dragAmount ->
                             change.consume()
                             offsetX = (offsetX + dragAmount)
-                                .coerceIn(-buttonWidthPx, buttonWidthPx)
+                                .coerceIn(0f, buttonWidthPx)
                         },
                         onDragEnd = {
                             offsetX = when {
                                 offsetX > buttonWidthPx / 2 -> {
                                     onOpen()
                                     buttonWidthPx
-                                }
-                                offsetX < -buttonWidthPx / 2 -> {
-                                    onOpen()
-                                    -buttonWidthPx
                                 }
                                 else -> {
                                     onClose()
@@ -493,7 +476,8 @@ private fun SwipableTransactionRow(
                             }
                         }
                     )
-                },
+                }
+                .clickable { onClick() },
             shape = RoundedCornerShape(12.dp),
             colors = CardDefaults.cardColors(
                 containerColor = MaterialTheme.colorScheme.surface
@@ -779,7 +763,7 @@ private fun LazyTransactionList(
                             isOpen = openedRowId == transaction.id,
                             onOpen = { openedRowId = transaction.id },
                             onClose = { openedRowId = null },
-                            onDetailsClick = { navigateToDetails(transaction) },
+                            onClick = { navigateToDetails(transaction) },
                             onDeleteTransaction = onDeleteTransaction
                         )
                     }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/bottomsheets/ExpenseTagsBottomSheetContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/bottomsheets/ExpenseTagsBottomSheetContent.kt
@@ -30,6 +30,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.unit.dp
 import banko.composeapp.generated.resources.Res
 import banko.composeapp.generated.resources.expense_tag_add_new
@@ -257,6 +259,9 @@ fun TagItem(
                 onValueChange = { editedName.value = it },
                 textStyle = MaterialTheme.typography.bodyMedium,
                 singleLine = true,
+                keyboardOptions = KeyboardOptions(
+                    capitalization = KeyboardCapitalization.Words,
+                ),
                 colors = TextFieldDefaults.colors(
                     focusedContainerColor = Color.Transparent,
                     unfocusedContainerColor = Color.Transparent,

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/bottomsheets/ExpenseTagsBottomSheetContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/bottomsheets/ExpenseTagsBottomSheetContent.kt
@@ -47,7 +47,7 @@ import com.banko.app.ui.components.dialogs.ErrorDetailDialog
 import com.banko.app.ui.models.ExpenseTag
 import com.banko.app.ui.screens.settings.SettingsScreenState
 import com.banko.app.ui.screens.settings.bottomsheets.dialogs.ExpenseTagAddNewDialog
-import com.banko.app.ui.screens.settings.bottomsheets.dialogs.ExpenseTagColorpickerDialog
+import com.banko.app.ui.screens.settings.bottomsheets.dialogs.ExpenseTagColorpickerBottomSheet
 import com.banko.app.ui.screens.settings.bottomsheets.dialogs.ExpenseTagDeleteDialog
 import com.banko.app.ui.utils.toUserMessage
 import org.jetbrains.compose.resources.painterResource
@@ -188,7 +188,7 @@ fun TagItem(
     }
 
     if (showColorPicker.value) {
-        ExpenseTagColorpickerDialog(
+        ExpenseTagColorpickerBottomSheet(
             showColorPicker = showColorPicker,
             editedColor = editedColor
         )

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/bottomsheets/dialogs/ExpenseTagAddNewDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/bottomsheets/dialogs/ExpenseTagAddNewDialog.kt
@@ -25,6 +25,8 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
+import androidx.compose.foundation.text.KeyboardOptions
+import androidx.compose.ui.text.input.KeyboardCapitalization
 import androidx.compose.ui.unit.dp
 import banko.composeapp.generated.resources.Res
 import banko.composeapp.generated.resources.expense_tag_add_new_button_cancel
@@ -104,6 +106,9 @@ fun ExpenseTagAddNewDialog(
                         textStyle = MaterialTheme.typography.bodyMedium,
                         singleLine = true,
                         isError = isError,
+                        keyboardOptions = KeyboardOptions(
+                            capitalization = KeyboardCapitalization.Words,
+                        ),
                         colors = TextFieldDefaults.colors(
                             focusedContainerColor = Color.Transparent,
                             unfocusedContainerColor = Color.Transparent,

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/bottomsheets/dialogs/ExpenseTagAddNewDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/bottomsheets/dialogs/ExpenseTagAddNewDialog.kt
@@ -50,7 +50,7 @@ fun ExpenseTagAddNewDialog(
     var isEarning by remember { mutableStateOf(false) }
 
     if (showColorPicker.value) {
-        ExpenseTagColorpickerDialog(
+        ExpenseTagColorpickerBottomSheet(
             showColorPicker = showColorPicker,
             editedColor = color
         )

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/bottomsheets/dialogs/ExpenseTagColorpickerDialog.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/bottomsheets/dialogs/ExpenseTagColorpickerDialog.kt
@@ -4,20 +4,39 @@ import androidx.compose.foundation.BorderStroke
 import androidx.compose.foundation.background
 import androidx.compose.foundation.border
 import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
-import androidx.compose.material3.AlertDialog
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material3.Button
+import androidx.compose.material3.ButtonDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.ModalBottomSheet
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
+import androidx.compose.material3.rememberModalBottomSheetState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
 import banko.composeapp.generated.resources.Res
@@ -27,52 +46,100 @@ import banko.composeapp.generated.resources.expense_tag_colorpicker_title
 import com.banko.app.ui.theme.colorList
 import org.jetbrains.compose.resources.stringResource
 
+@OptIn(ExperimentalMaterial3Api::class)
 @Composable
-fun ExpenseTagColorpickerDialog(
+fun ExpenseTagColorpickerBottomSheet(
     showColorPicker: MutableState<Boolean>,
     editedColor: MutableState<Color>
 ) {
-    AlertDialog(
+    val sheetState = rememberModalBottomSheetState(skipPartiallyExpanded = true)
+    var selectedColor by remember { mutableStateOf(editedColor.value) }
+
+    ModalBottomSheet(
         onDismissRequest = { showColorPicker.value = false },
-        confirmButton = {
-            TextButton(onClick = { showColorPicker.value = false }) {
-                Text(
-                    text = stringResource(Res.string.expense_tag_colorpicker_button_ok)
-                )
-            }
-        },
-        dismissButton = {
-            TextButton(onClick = { showColorPicker.value = false }) {
-                Text(
-                    text = stringResource(Res.string.expense_tag_colorpicker_button_cancel)
-                )
-            }
-        },
-        title = {
+        sheetState = sheetState,
+        containerColor = MaterialTheme.colorScheme.surface,
+    ) {
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .padding(horizontal = 16.dp, vertical = 8.dp)
+        ) {
             Text(
                 text = stringResource(Res.string.expense_tag_colorpicker_title),
-                color = MaterialTheme.colorScheme.primary
+                color = MaterialTheme.colorScheme.primary,
+                style = MaterialTheme.typography.titleMedium
             )
-        },
-        text = {
+
+            Spacer(modifier = Modifier.height(16.dp))
+
             LazyVerticalGrid(
-                columns = GridCells.Fixed(4),
+                columns = GridCells.Fixed(6),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
+                verticalArrangement = Arrangement.spacedBy(12.dp),
                 modifier = Modifier.fillMaxWidth()
             ) {
-                itemsIndexed(colorList) { index, color ->
+                itemsIndexed(colorList) { _, color ->
+                    val isSelected = color == selectedColor
                     Box(
                         modifier = Modifier
-                            .size(50.dp)
-                            .border(BorderStroke(5.dp, MaterialTheme.colorScheme.onSurface))
+                            .size(44.dp)
+                            .clip(CircleShape)
                             .background(color)
-                            .padding(50.dp)
-                            .clickable {
-                                editedColor.value = color
-                                showColorPicker.value = false
-                            }
+                            .then(
+                                if (isSelected) {
+                                    Modifier.border(BorderStroke(3.dp, MaterialTheme.colorScheme.primary), CircleShape)
+                                } else {
+                                    Modifier.border(BorderStroke(1.dp, MaterialTheme.colorScheme.onSurface.copy(alpha = 0.2f)), CircleShape)
+                                }
+                            )
+                            .clickable { selectedColor = color },
+                        contentAlignment = Alignment.Center
+                    ) {
+                        if (isSelected) {
+                            Icon(
+                                imageVector = Icons.Default.Check,
+                                contentDescription = null,
+                                tint = if (color.luminance() > 0.5f) Color.Black else Color.White,
+                                modifier = Modifier.size(20.dp)
+                            )
+                        }
+                    }
+                }
+            }
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            Row(
+                modifier = Modifier.fillMaxWidth(),
+                horizontalArrangement = Arrangement.End
+            ) {
+                TextButton(onClick = { showColorPicker.value = false }) {
+                    Text(
+                        text = stringResource(Res.string.expense_tag_colorpicker_button_cancel),
+                        color = MaterialTheme.colorScheme.primary.copy(alpha = 0.7f)
+                    )
+                }
+                Button(
+                    onClick = {
+                        editedColor.value = selectedColor
+                        showColorPicker.value = false
+                    },
+                    colors = ButtonDefaults.buttonColors(
+                        containerColor = MaterialTheme.colorScheme.primary
+                    )
+                ) {
+                    Text(
+                        text = stringResource(Res.string.expense_tag_colorpicker_button_ok)
                     )
                 }
             }
+
+            Spacer(modifier = Modifier.height(16.dp))
         }
-    )
+    }
+}
+
+private fun Color.luminance(): Float {
+    return 0.299f * red + 0.587f * green + 0.114f * blue
 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/theme/Color.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/theme/Color.kt
@@ -53,6 +53,33 @@ val MidnightBlue = Color(0xFF191970)    // Dark, saturated blue
 val Chartreuse = Color(0xFF7FFF00)      // Bright greenish-yellow
 val Olive = Color(0xFF808000)           // Muted green-brown
 
+// Additional Blue
+val CornflowerBlue = Color(0xFF6495ED)  // Soft medium blue
+val RoyalBlue = Color(0xFF4169E1)       // Vivid blue
+val PowderBlue = Color(0xFFB0E0E6)      // Light pastel blue
+
+// Additional Purple
+val Plum = Color(0xFFDDA0DD)            // Soft pink-purple
+val Mauve = Color(0xFFE0B0FF)           // Light purple-pink
+
+// Additional Green
+val SageGreen = Color(0xFF9DC183)       // Muted earthy green
+val MintGreen = Color(0xFF98FF98)       // Bright mint
+
+// Additional Orange/Yellow
+val Gold = Color(0xFFFFD700)            // Pure gold
+val Banana = Color(0xFFFAE199)          // Soft yellow
+
+// Additional Red
+val Crimson = Color(0xFFDC143C)         // Bright deep red
+val Tomato = Color(0xFFFF6347)          // Orange-red
+val RosyBrown = Color(0xFFBC8F8F)       // Muted pink-brown
+
+// Additional Neutrals
+val Taupe = Color(0xFF483C32)           // Dark warm brown
+val Umber = Color(0xFF635147)           // Earthy brown
+val Onyx = Color(0xFF353839)            // Near-black
+
 val Darkmode_Primary = Color(0xBB86FCFF)
 val Darkmode_PrimaryVariant = Color(0x3700B3FF)
 val Darkmode_Secondary = Teal
@@ -66,31 +93,59 @@ val Light_Surface = Color(0xFFFFFFF0)
 val Light_On_Surface = Color(0xFFF2EFDE)
 
 val colorList: List<Color> = listOf(
+    // Blues
     SteelBlue,
     DeepSkyBlue,
     DodgerBlue,
     DarkMidnightBlue,
+    MidnightBlue,
+    CadetBlue,
+    CornflowerBlue,
+    RoyalBlue,
+    PowderBlue,
+
+    // Purples
     MediumPurple,
     Lavender,
     DarkOrchid,
     PatriarchPurple,
+    Plum,
+    Mauve,
+
+    // Greens
     MediumSeaGreen,
     LimeGreen,
     DarkOliveGreen,
     Teal,
+    Chartreuse,
+    Olive,
+    SageGreen,
+    MintGreen,
+
+    // Oranges & Yellows
     Orange,
     Amber,
     Coral,
+    PeachPuff,
+    LightGoldenrodYellow,
+    Gold,
+    Banana,
+
+    // Reds
     Firebrick,
+    Crimson,
+    Tomato,
+    RosyBrown,
+
+    // Turquoises & Cyans
     DarkTurquoise,
     Aqua,
+
+    // Neutrals
     DarkSlateGray,
     LightSlateGray,
     Gainsboro,
-    PeachPuff,
-    LightGoldenrodYellow,
-    CadetBlue,
-    MidnightBlue,
-    Chartreuse,
-    Olive
+    Taupe,
+    Umber,
+    Onyx
 )


### PR DESCRIPTION
## What

- Navigate to details screen on transaction tap, remove swipe-to-reveal details button
- Swipe right to reveal delete button (instead of swipe left for details)
- Make expense tag box fully clickable to open dropdown
- Save tag immediately on selection, remove save button
- Replace DropdownMenu with custom Popup, scrollable with max 7 items and fade indicators
- Redesign color picker as bottom sheet with circular swatches and checkmark selection
- Expand color palette from 27 to 42 colors
- Add keyboard capitalization to all editable text fields (except passwords)

## Why

- Tapping a transaction to navigate is more intuitive than swiping to reveal a details button
- Swiping right for delete follows the standard mobile pattern (iOS swipe-to-delete)
- Clicking anywhere on the expense tag box is more accessible than only the arrow icon
- Saving tags on selection removes an unnecessary extra tap
- Scroll indicators in the dropdown help users discover more options
- Bottom sheet color picker feels more native in settings and allows browsing before confirming
- More colors give users better tag personalization
- Keyboard capitalization improves typing experience across the app