### PR TITLE
Feature/bank linking

### DIFF
--- a/composeApp/src/androidMain/AndroidManifest.xml
+++ b/composeApp/src/androidMain/AndroidManifest.xml
@@ -12,12 +12,21 @@
         android:theme="@android:style/Theme.Material.Light.NoActionBar">
         <activity
             android:exported="true"
+            android:launchMode="singleTask"
             android:configChanges="orientation|screenSize|screenLayout|keyboardHidden|mnc|colorMode|density|fontScale|fontWeightAdjustment|keyboard|layoutDirection|locale|mcc|navigation|smallestScreenSize|touchscreen|uiMode"
             android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
 
                 <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <category android:name="android.intent.category.BROWSABLE" />
+                <data
+                    android:scheme="banko"
+                    android:host="bank-auth-callback" />
             </intent-filter>
         </activity>
     </application>

--- a/composeApp/src/androidMain/kotlin/com/banko/app/ui/components/BankLinkingWebView.android.kt
+++ b/composeApp/src/androidMain/kotlin/com/banko/app/ui/components/BankLinkingWebView.android.kt
@@ -1,0 +1,77 @@
+package com.banko.app.ui.components
+
+import android.annotation.SuppressLint
+import android.webkit.WebResourceRequest
+import android.webkit.WebView
+import android.webkit.WebViewClient
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.DisposableEffect
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.viewinterop.AndroidView
+
+private const val REDIRECT_PREFIX = "Banko://"
+
+@SuppressLint("SetJavaScriptEnabled")
+@Composable
+actual fun BankLinkingWebView(
+    url: String,
+    onRedirectDetected: (url: String) -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier,
+) {
+    var webView by remember { mutableStateOf<WebView?>(null) }
+
+    BackHandler {
+        val wv = webView
+        if (wv != null && wv.canGoBack()) {
+            wv.goBack()
+        } else {
+            onBack()
+        }
+    }
+
+    AndroidView(
+        factory = { context ->
+            WebView(context).apply {
+                settings.javaScriptEnabled = true
+                settings.domStorageEnabled = true
+                settings.allowFileAccess = true
+                settings.databaseEnabled = true
+
+                webViewClient = object : WebViewClient() {
+                    override fun shouldOverrideUrlLoading(
+                        view: WebView?,
+                        request: WebResourceRequest?
+                    ): Boolean {
+                        val requestUrl = request?.url?.toString() ?: return false
+                        if (requestUrl.startsWith(REDIRECT_PREFIX, ignoreCase = true)) {
+                            onRedirectDetected(requestUrl)
+                            return true
+                        }
+                        return false
+                    }
+                }
+
+                loadUrl(url)
+                webView = this
+            }
+        },
+        modifier = modifier.fillMaxSize(),
+    )
+
+    DisposableEffect(Unit) {
+        onDispose {
+            webView?.apply {
+                stopLoading()
+                destroy()
+            }
+            webView = null
+        }
+    }
+}

--- a/composeApp/src/androidUnitTest/kotlin/com/banko/app/ui/screens/settings/SettingsScreenViewModelTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/banko/app/ui/screens/settings/SettingsScreenViewModelTest.kt
@@ -2,6 +2,7 @@ package com.banko.app.ui.screens.settings
 
 import androidx.compose.ui.graphics.Color
 import com.banko.app.api.repositories.ExpenseTagRepository
+import com.banko.app.api.services.BankoApiService
 import com.banko.app.database.Entities.ExpenseTag as DaoExpenseTag
 import com.banko.app.domain.CurrencyPreferences
 import com.banko.app.database.repository.ExpenseTagRepository as DatabaseExpenseTagRepository
@@ -30,6 +31,7 @@ class SettingsScreenViewModelTest {
     private val dbRepository = mockk<DatabaseExpenseTagRepository>(relaxed = true)
     private val apiRepository = mockk<ExpenseTagRepository>(relaxed = true)
     private val currencyPreferences = mockk<CurrencyPreferences>(relaxed = true)
+    private val apiService = mockk<BankoApiService>(relaxed = true)
     private val testDispatcher: TestDispatcher = StandardTestDispatcher()
 
     @Before
@@ -48,7 +50,8 @@ class SettingsScreenViewModelTest {
         val vm = SettingsScreenViewModel(
             dbRepository = dbRepository,
             apiRepository = apiRepository,
-            currencyPreferences = currencyPreferences
+            currencyPreferences = currencyPreferences,
+            apiService = apiService,
         )
         advanceUntilIdle()
 
@@ -67,7 +70,8 @@ class SettingsScreenViewModelTest {
         val vm = SettingsScreenViewModel(
             dbRepository = dbRepository,
             apiRepository = apiRepository,
-            currencyPreferences = currencyPreferences
+            currencyPreferences = currencyPreferences,
+            apiService = apiService,
         )
         advanceUntilIdle()
 
@@ -88,7 +92,8 @@ class SettingsScreenViewModelTest {
         val vm = SettingsScreenViewModel(
             dbRepository = dbRepository,
             apiRepository = apiRepository,
-            currencyPreferences = currencyPreferences
+            currencyPreferences = currencyPreferences,
+            apiService = apiService,
         )
         advanceUntilIdle()
 
@@ -108,7 +113,8 @@ class SettingsScreenViewModelTest {
         val vm = SettingsScreenViewModel(
             dbRepository = dbRepository,
             apiRepository = apiRepository,
-            currencyPreferences = currencyPreferences
+            currencyPreferences = currencyPreferences,
+            apiService = apiService,
         )
         advanceUntilIdle()
 
@@ -128,7 +134,8 @@ class SettingsScreenViewModelTest {
         val vm = SettingsScreenViewModel(
             dbRepository = dbRepository,
             apiRepository = apiRepository,
-            currencyPreferences = currencyPreferences
+            currencyPreferences = currencyPreferences,
+            apiService = apiService,
         )
         advanceUntilIdle()
 
@@ -148,7 +155,8 @@ class SettingsScreenViewModelTest {
         val vm = SettingsScreenViewModel(
             dbRepository = dbRepository,
             apiRepository = apiRepository,
-            currencyPreferences = currencyPreferences
+            currencyPreferences = currencyPreferences,
+            apiService = apiService,
         )
         advanceUntilIdle()
 
@@ -163,7 +171,8 @@ class SettingsScreenViewModelTest {
         val vm = SettingsScreenViewModel(
             dbRepository = dbRepository,
             apiRepository = apiRepository,
-            currencyPreferences = currencyPreferences
+            currencyPreferences = currencyPreferences,
+            apiService = apiService,
         )
         advanceUntilIdle()
 

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -105,4 +105,33 @@
     <string name="profile_delete_account_confirm_yes">Delete</string>
     <string name="profile_delete_account_confirm_cancel">Cancel</string>
     <string name="profile_re_accept_consent">Re-accept Privacy Policy</string>
+
+    <!-- Bank Linking -->
+    <string name="add_new_bank">Add New Bank</string>
+    <string name="add_new_bank_description">Link a bank account</string>
+    <string name="linked_banks">Linked Banks</string>
+    <string name="no_linked_banks">No linked banks yet</string>
+    <string name="select_country">Select Country</string>
+    <string name="select_country_description">Choose your bank\'s country</string>
+    <string name="search_countries">Search countries…</string>
+    <string name="search_banks">Search banks…</string>
+    <string name="select_bank">Select Bank</string>
+    <string name="select_bank_description">Choose your bank</string>
+    <string name="no_banks_found">No banks found for this country</string>
+    <string name="linking_account">Linking your account…</string>
+    <string name="account_linked_successfully">Account linked successfully!</string>
+    <string name="linked_accounts">Linked Accounts</string>
+    <string name="account_linking_failed">Account linking failed</string>
+    <string name="re_authorize">Re-authorize</string>
+    <string name="linked">Linked</string>
+    <string name="processing">Processing</string>
+    <string name="expired">Expired</string>
+    <string name="error_status">Error</string>
+    <string name="done">Done</string>
+    <string name="bank_auth_error">Bank authorization error</string>
+    <string name="bank_auth_error_description">Authorization was cancelled or failed. Please try again.</string>
+    <string name="retry">Retry</string>
+    <string name="back">Back</string>
+    <string name="banks">BANKS</string>
+    <string name="iban_label">IBAN: %s</string>
 </resources>

--- a/composeApp/src/commonMain/kotlin/com/banko/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/App.kt
@@ -23,6 +23,7 @@ import com.arkivanov.decompose.router.stack.pushNew
 import com.banko.app.api.auth.AuthState
 import com.banko.app.ui.screens.auth.AuthComponent
 import com.banko.app.ui.screens.auth.AuthScreen
+import com.banko.app.ui.screens.banklinking.BankLinkingScreen
 import com.banko.app.ui.screens.details.DetailsScreen
 import com.banko.app.ui.screens.details.DetailsScreenViewModel
 import com.banko.app.ui.screens.home.HomeScreen
@@ -95,6 +96,7 @@ fun App(root: RootComponent, authComponent: AuthComponent) {
                                 )
                                 is RootComponent.Child.Settings -> SettingsScreen(instance.component)
                                 is RootComponent.Child.Profile -> ProfileScreen(instance.component)
+                                is RootComponent.Child.BankLinking -> BankLinkingScreen(instance.component)
                             }
                         }
                     }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/api/dto/bankoApi/BankAuthorization.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/api/dto/bankoApi/BankAuthorization.kt
@@ -1,0 +1,118 @@
+package com.banko.app.api.dto.bankoApi
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+@Serializable
+enum class BankAuthorizationStatus {
+    Processing,
+    Linked,
+    Error,
+    Expired
+}
+
+@Serializable
+data class GoCardlessInstitutionDto(
+    val id: String = "",
+    val name: String = "",
+    val bic: String = "",
+    @SerialName("transaction_total_days")
+    val transactionTotalDays: String = "",
+    val countries: List<String> = emptyList(),
+    val logo: String = "",
+    @SerialName("max_access_valid_for_days")
+    val maxAccessValidForDays: String = "",
+)
+
+@Serializable
+data class UpsertEndUserAgreementRequest(
+    @SerialName("institutionId")
+    val institutionId: String,
+    @SerialName("daysOfAccess")
+    val daysOfAccess: Int = 90,
+)
+
+@Serializable
+data class UpsertEndUserAgreementResponse(
+    val link: String = "",
+    @SerialName("requisitionId")
+    val requisitionId: String = "",
+    @SerialName("agreementId")
+    val agreementId: String = "",
+    @SerialName("referenceId")
+    val referenceId: String = "",
+    @SerialName("institutionId")
+    val institutionId: String = "",
+    @SerialName("bankAuthorizationId")
+    val bankAuthorizationId: String = "",
+)
+
+@Serializable
+data class BankAuthCallbackRequest(
+    @SerialName("requisitionId")
+    val requisitionId: String,
+)
+
+@Serializable
+data class BankAuthCallbackResponse(
+    @SerialName("bankAuthorizationId")
+    val bankAuthorizationId: String = "",
+    val status: BankAuthorizationStatus = BankAuthorizationStatus.Processing,
+    @SerialName("linkedAccounts")
+    val linkedAccounts: List<LinkedBankAccount> = emptyList(),
+)
+
+@Serializable
+data class LinkedBankAccount(
+    @SerialName("bankAccountId")
+    val bankAccountId: String = "",
+    val iban: String? = null,
+    val currency: String? = null,
+    @SerialName("ownerName")
+    val ownerName: String? = null,
+    @SerialName("accountName")
+    val accountName: String? = null,
+    val product: String? = null,
+)
+
+@Serializable
+data class GetBankAuthorizationsResponse(
+    @SerialName("bankAuthorizations")
+    val bankAuthorizations: List<BankAuthDto> = emptyList(),
+)
+
+@Serializable
+data class BankAuthDto(
+    val id: String = "",
+    @SerialName("userId")
+    val userId: String = "",
+    @SerialName("requisitionId")
+    val requisitionId: String? = null,
+    @SerialName("institutionId")
+    val institutionId: String? = null,
+    @SerialName("referenceId")
+    val referenceId: String? = null,
+    @SerialName("agreementId")
+    val agreementId: String? = null,
+    val status: BankAuthorizationStatus = BankAuthorizationStatus.Processing,
+    @SerialName("institutionName")
+    val institutionName: String? = null,
+    @SerialName("createdAt")
+    val createdAt: String = "",
+    @SerialName("updatedAt")
+    val updatedAt: String = "",
+    val accounts: List<BankAccountSummaryDto> = emptyList(),
+)
+
+@Serializable
+data class BankAccountSummaryDto(
+    @SerialName("bankAccountId")
+    val bankAccountId: String = "",
+    val iban: String? = null,
+    val currency: String? = null,
+    @SerialName("ownerName")
+    val ownerName: String? = null,
+    @SerialName("accountName")
+    val accountName: String? = null,
+    val product: String? = null,
+)

--- a/composeApp/src/commonMain/kotlin/com/banko/app/api/dto/bankoApi/BankAuthorization.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/api/dto/bankoApi/BankAuthorization.kt
@@ -97,6 +97,8 @@ data class BankAuthDto(
     val status: BankAuthorizationStatus = BankAuthorizationStatus.Processing,
     @SerialName("institutionName")
     val institutionName: String? = null,
+    @SerialName("institutionLogoUrl")
+    val institutionLogoUrl: String? = null,
     @SerialName("createdAt")
     val createdAt: String = "",
     @SerialName("updatedAt")

--- a/composeApp/src/commonMain/kotlin/com/banko/app/api/services/BankoApiService.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/api/services/BankoApiService.kt
@@ -4,14 +4,20 @@ import com.banko.app.api.HttpClientProvider
 import com.banko.app.api.auth.TokenStorage
 import com.banko.app.api.dto.bankoApi.AcceptConsentRequest
 import com.banko.app.api.dto.bankoApi.AuthResponse
+import com.banko.app.api.dto.bankoApi.BankAuthCallbackRequest
+import com.banko.app.api.dto.bankoApi.BankAuthCallbackResponse
 import com.banko.app.api.dto.bankoApi.ChangePasswordRequest
 import com.banko.app.api.dto.bankoApi.ExpenseTag
 import com.banko.app.api.dto.bankoApi.ExpenseTags
+import com.banko.app.api.dto.bankoApi.GetBankAuthorizationsResponse
+import com.banko.app.api.dto.bankoApi.GoCardlessInstitutionDto
 import com.banko.app.api.dto.bankoApi.LoginRequest
 import com.banko.app.api.dto.bankoApi.RefreshRequest
 import com.banko.app.api.dto.bankoApi.RegisterRequest
 import com.banko.app.api.dto.bankoApi.Transactions
 import com.banko.app.api.dto.bankoApi.UpdateProfileRequest
+import com.banko.app.api.dto.bankoApi.UpsertEndUserAgreementRequest
+import com.banko.app.api.dto.bankoApi.UpsertEndUserAgreementResponse
 import com.banko.app.api.dto.bankoApi.UpsertExpenseTag
 import com.banko.app.api.dto.bankoApi.UserExportData
 import com.banko.app.api.dto.bankoApi.UserProfileResponse
@@ -245,6 +251,41 @@ class BankoApiService(
 
     suspend fun deleteAccount(): Result<Unit> {
         return client.deleteSafe("$baseUrl/Users/me") {
+            contentType(ContentType.Application.Json)
+        }
+    }
+
+    suspend fun getInstitutions(country: String): Result<List<GoCardlessInstitutionDto>> {
+        return client.getSafe<List<GoCardlessInstitutionDto>>("$baseUrl/Settings/institutions") {
+            contentType(ContentType.Application.Json)
+            parameter("country", country)
+        }
+    }
+
+    suspend fun upsertEndUserAgreement(
+        institutionId: String,
+        daysOfAccess: Int = 90
+    ): Result<UpsertEndUserAgreementResponse> {
+        return client.postSafe("$baseUrl/Settings/end-user-agreement") {
+            contentType(ContentType.Application.Json)
+            setBody(
+                UpsertEndUserAgreementRequest(
+                    institutionId = institutionId,
+                    daysOfAccess = daysOfAccess,
+                )
+            )
+        }
+    }
+
+    suspend fun bankAuthCallback(requisitionId: String): Result<BankAuthCallbackResponse> {
+        return client.postSafe("$baseUrl/Settings/bank-auth-callback") {
+            contentType(ContentType.Application.Json)
+            setBody(BankAuthCallbackRequest(requisitionId = requisitionId))
+        }
+    }
+
+    suspend fun getBankAuthorizations(): Result<GetBankAuthorizationsResponse> {
+        return client.getSafe("$baseUrl/Settings/BankAuthorization") {
             contentType(ContentType.Application.Json)
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/api/utils/jsonAdapters/JsonProvider.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/api/utils/jsonAdapters/JsonProvider.kt
@@ -9,6 +9,7 @@ object JsonProvider {
         prettyPrint = true
         isLenient = true
         ignoreUnknownKeys = true
+        encodeDefaults = true
         serializersModule = SerializersModule {
             contextual(ColorSerializer) // Register Color serializer globally
         }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/di/Modules.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/di/Modules.kt
@@ -22,6 +22,7 @@ import com.banko.app.domain.CurrencyPreferences
 import com.banko.app.domain.GetAllExpenseTagUseCase
 import com.banko.app.domain.SaveNoteUseCase
 import com.banko.app.ui.screens.details.DetailsScreenViewModel
+import com.banko.app.ui.screens.banklinking.BankLinkingViewModel
 import com.banko.app.ui.screens.home.HomeScreenViewModel
 import com.banko.app.ui.screens.login.LoginViewModel
 import com.banko.app.ui.screens.profile.ProfileViewModel
@@ -63,6 +64,7 @@ val  sharedModule = module {
     viewModelOf(::SettingsScreenViewModel)
     viewModelOf(::HomeScreenViewModel)
     viewModelOf(::DetailsScreenViewModel)
+    viewModelOf(::BankLinkingViewModel)
 }
 
 //    Example 1

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/BankLinkingWebView.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/BankLinkingWebView.kt
@@ -1,0 +1,12 @@
+package com.banko.app.ui.components
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+
+expect @Composable
+fun BankLinkingWebView(
+    url: String,
+    onRedirectDetected: (url: String) -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier = Modifier,
+)

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/banklinking/BankLinkingComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/banklinking/BankLinkingComponent.kt
@@ -1,0 +1,9 @@
+package com.banko.app.ui.screens.banklinking
+
+import com.arkivanov.decompose.ComponentContext
+
+class BankLinkingComponent(
+    componentContext: ComponentContext,
+    val onGoBack: () -> Unit = {},
+    val institutionId: String? = null,
+) : ComponentContext by componentContext

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/banklinking/BankLinkingScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/banklinking/BankLinkingScreen.kt
@@ -1,0 +1,598 @@
+package com.banko.app.ui.screens.banklinking
+
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.automirrored.filled.ArrowBack
+import androidx.compose.material.icons.filled.Check
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material.icons.filled.Search
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TextFieldColors
+import androidx.compose.material3.TextFieldDefaults
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.unit.dp
+import banko.composeapp.generated.resources.Res
+import banko.composeapp.generated.resources.account_linked_successfully
+import banko.composeapp.generated.resources.account_linking_failed
+import banko.composeapp.generated.resources.back
+import banko.composeapp.generated.resources.bank_auth_error
+import banko.composeapp.generated.resources.bank_auth_error_description
+import banko.composeapp.generated.resources.done
+import banko.composeapp.generated.resources.iban_label
+import banko.composeapp.generated.resources.linked_accounts
+import banko.composeapp.generated.resources.linking_account
+import banko.composeapp.generated.resources.no_banks_found
+import banko.composeapp.generated.resources.retry
+import banko.composeapp.generated.resources.search_banks
+import banko.composeapp.generated.resources.search_countries
+import banko.composeapp.generated.resources.select_bank
+import banko.composeapp.generated.resources.select_country
+import banko.composeapp.generated.resources.select_country_description
+import banko.composeapp.generated.resources.select_bank_description
+import com.banko.app.ui.components.BankLinkingWebView
+import com.banko.app.ui.components.BankLogo
+import org.jetbrains.compose.resources.stringResource
+import org.koin.compose.viewmodel.koinViewModel
+import org.koin.core.annotation.KoinExperimentalAPI
+
+@OptIn(ExperimentalMaterial3Api::class, KoinExperimentalAPI::class)
+@Composable
+fun BankLinkingScreen(
+    component: com.banko.app.ui.screens.banklinking.BankLinkingComponent,
+) {
+    val viewModel = koinViewModel<BankLinkingViewModel>()
+    val screenState by viewModel.screenState.collectAsState()
+
+    val institutionId = component.institutionId
+    LaunchedEffect(institutionId) {
+        if (institutionId != null && screenState.currentStep == BankLinkingStep.CountrySelection) {
+            viewModel.reAuthorize(institutionId)
+        }
+    }
+
+    val title = when (screenState.currentStep) {
+        BankLinkingStep.CountrySelection -> stringResource(Res.string.select_country)
+        BankLinkingStep.BankSelection -> stringResource(Res.string.select_bank)
+        BankLinkingStep.Authorizing -> screenState.selectedInstitution?.name ?: stringResource(Res.string.select_bank)
+        BankLinkingStep.Processing -> stringResource(Res.string.linking_account)
+        BankLinkingStep.Success -> stringResource(Res.string.account_linked_successfully)
+        BankLinkingStep.Error -> stringResource(Res.string.account_linking_failed)
+    }
+
+    val canGoBack = screenState.currentStep in listOf(
+        BankLinkingStep.CountrySelection,
+        BankLinkingStep.BankSelection,
+    )
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text(text = title, color = MaterialTheme.colorScheme.primary) },
+                navigationIcon = {
+                    if (canGoBack) {
+                        IconButton(onClick = { viewModel.goBack() }) {
+                            Icon(
+                                imageVector = Icons.AutoMirrored.Filled.ArrowBack,
+                                contentDescription = stringResource(Res.string.back),
+                                tint = MaterialTheme.colorScheme.primary,
+                            )
+                        }
+                    }
+                },
+                colors = TopAppBarDefaults.topAppBarColors(
+                    containerColor = MaterialTheme.colorScheme.surface,
+                ),
+            )
+        }
+    ) { paddingValues ->
+        Box(
+            modifier = Modifier
+                .fillMaxSize()
+                .padding(paddingValues),
+        ) {
+            when (screenState.currentStep) {
+                BankLinkingStep.CountrySelection -> CountrySelectionStep(
+                    onSelectCountry = { viewModel.selectCountry(it) },
+                )
+                BankLinkingStep.BankSelection -> BankSelectionStep(
+                    institutions = screenState.institutions,
+                    isLoading = screenState.isLoading,
+                    onSelectInstitution = { viewModel.selectInstitution(it) },
+                )
+                BankLinkingStep.Authorizing -> {
+                    val authUrl = screenState.authUrl
+                    if (authUrl != null) {
+                        BankLinkingWebView(
+                            url = authUrl,
+                            onRedirectDetected = { url -> viewModel.onWebViewRedirect(url) },
+                            onBack = { viewModel.onWebViewBack() },
+                        )
+                    } else {
+                        CircularProgressIndicator(
+                            modifier = Modifier.align(Alignment.Center),
+                        )
+                    }
+                }
+                BankLinkingStep.Processing -> ProcessingStep()
+                BankLinkingStep.Success -> SuccessStep(
+                    linkedAccounts = screenState.linkedAccounts,
+                    onDone = { viewModel.done() },
+                )
+                BankLinkingStep.Error -> ErrorStep(
+                    errorMessage = screenState.error,
+                    onRetry = { viewModel.retry() },
+                    onBack = { component.onGoBack() },
+                )
+            }
+
+            if (screenState.isLoading && screenState.currentStep != BankLinkingStep.Processing) {
+                CircularProgressIndicator(
+                    modifier = Modifier.align(Alignment.Center),
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun CountrySelectionStep(
+    onSelectCountry: (Country) -> Unit,
+) {
+    var searchQuery by remember { mutableStateOf("") }
+
+    val filteredPopular = remember(searchQuery) {
+        if (searchQuery.isBlank()) popularCountries
+        else popularCountries.filter {
+            it.name.contains(searchQuery, ignoreCase = true) ||
+                    it.code.contains(searchQuery, ignoreCase = true)
+        }
+    }
+
+    val filteredAll = remember(searchQuery) {
+        if (searchQuery.isBlank()) allCountries
+        else allCountries.filter {
+            it.name.contains(searchQuery, ignoreCase = true) ||
+                    it.code.contains(searchQuery, ignoreCase = true)
+        }
+    }
+
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp),
+    ) {
+        item {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(Res.string.select_country_description),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            OutlinedTextField(
+                value = searchQuery,
+                onValueChange = { searchQuery = it },
+                colors = TextFieldDefaults.colors(
+                    focusedTextColor = MaterialTheme.colorScheme.onBackground
+                ),
+                modifier = Modifier.fillMaxWidth(),
+                placeholder = { Text(stringResource(Res.string.search_countries)) },
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Default.Search,
+                        contentDescription = null,
+                    )
+                },
+                singleLine = true,
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+
+        if (filteredPopular.isNotEmpty()) {
+            item {
+                Text(
+                    text = "Popular",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+
+            items(filteredPopular) { country ->
+                CountryItem(
+                    country = country,
+                    onClick = { onSelectCountry(country) },
+                )
+            }
+
+            item {
+                Spacer(modifier = Modifier.height(16.dp))
+                HorizontalDivider()
+                Spacer(modifier = Modifier.height(16.dp))
+            }
+        }
+
+        if (filteredAll.isNotEmpty()) {
+            item {
+                Text(
+                    text = "All Countries",
+                    style = MaterialTheme.typography.titleSmall,
+                    color = MaterialTheme.colorScheme.primary,
+                )
+                Spacer(modifier = Modifier.height(8.dp))
+            }
+
+            items(filteredAll) { country ->
+                CountryItem(
+                    country = country,
+                    onClick = { onSelectCountry(country) },
+                )
+            }
+        }
+
+        item {
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun CountryItem(
+    country: Country,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = country.code,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.primary,
+            modifier = Modifier.width(40.dp),
+        )
+        Text(
+            text = country.name,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.primary,
+        )
+    }
+}
+
+@Composable
+private fun BankSelectionStep(
+    institutions: List<com.banko.app.api.dto.bankoApi.GoCardlessInstitutionDto>,
+    isLoading: Boolean,
+    onSelectInstitution: (com.banko.app.api.dto.bankoApi.GoCardlessInstitutionDto) -> Unit,
+) {
+    var searchQuery by remember { mutableStateOf("") }
+
+    val filteredInstitutions = remember(searchQuery, institutions) {
+        if (searchQuery.isBlank()) institutions
+        else institutions.filter {
+            it.name.contains(searchQuery, ignoreCase = true)
+        }
+    }
+
+    if (isLoading && institutions.isEmpty()) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            CircularProgressIndicator()
+        }
+        return
+    }
+
+    if (institutions.isEmpty()) {
+        Box(
+            modifier = Modifier.fillMaxSize(),
+            contentAlignment = Alignment.Center,
+        ) {
+            Text(
+                text = stringResource(Res.string.no_banks_found),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+        return
+    }
+
+    LazyColumn(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(horizontal = 16.dp),
+    ) {
+        item {
+            Spacer(modifier = Modifier.height(8.dp))
+            Text(
+                text = stringResource(Res.string.select_bank_description),
+                style = MaterialTheme.typography.bodyMedium,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+            OutlinedTextField(
+                value = searchQuery,
+                onValueChange = { searchQuery = it },
+                modifier = Modifier.fillMaxWidth(),
+                placeholder = { Text(stringResource(Res.string.search_banks)) },
+                leadingIcon = {
+                    Icon(
+                        imageVector = Icons.Default.Search,
+                        contentDescription = null,
+                    )
+                },
+                singleLine = true,
+            )
+            Spacer(modifier = Modifier.height(12.dp))
+        }
+
+        items(filteredInstitutions) { institution ->
+            BankInstitutionItem(
+                institution = institution,
+                onClick = { onSelectInstitution(institution) },
+            )
+        }
+
+        item {
+            Spacer(modifier = Modifier.height(16.dp))
+        }
+    }
+}
+
+@Composable
+private fun BankInstitutionItem(
+    institution: com.banko.app.api.dto.bankoApi.GoCardlessInstitutionDto,
+    onClick: () -> Unit,
+) {
+    Row(
+        modifier = Modifier
+            .fillMaxWidth()
+            .clickable(onClick = onClick)
+            .padding(vertical = 12.dp),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        BankLogo(
+            logoUrl = institution.logo,
+            bankName = institution.name,
+            size = 40,
+        )
+        Spacer(modifier = Modifier.width(16.dp))
+        Text(
+            text = institution.name,
+            style = MaterialTheme.typography.bodyLarge,
+            color = MaterialTheme.colorScheme.primary,
+        )
+    }
+}
+
+@Composable
+private fun ProcessingStep() {
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.Center,
+        ) {
+            CircularProgressIndicator(modifier = Modifier.size(48.dp))
+            Spacer(modifier = Modifier.height(16.dp))
+            Text(
+                text = stringResource(Res.string.linking_account),
+                style = MaterialTheme.typography.bodyLarge,
+                color = MaterialTheme.colorScheme.primary,
+            )
+        }
+    }
+}
+
+@Composable
+private fun SuccessStep(
+    linkedAccounts: List<com.banko.app.api.dto.bankoApi.LinkedBankAccount>,
+    onDone: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Icon(
+            imageVector = Icons.Default.Check,
+            contentDescription = null,
+            modifier = Modifier.size(72.dp),
+            tint = MaterialTheme.colorScheme.primary,
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = stringResource(Res.string.account_linked_successfully),
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.primary,
+            textAlign = TextAlign.Center,
+        )
+
+        Spacer(modifier = Modifier.height(24.dp))
+
+        if (linkedAccounts.isNotEmpty()) {
+            Text(
+                text = stringResource(Res.string.linked_accounts),
+                style = MaterialTheme.typography.titleSmall,
+                color = MaterialTheme.colorScheme.primary,
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+
+            linkedAccounts.forEach { account ->
+                Card(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(vertical = 4.dp),
+                ) {
+                    Column(
+                        modifier = Modifier.padding(16.dp),
+                    ) {
+                        account.accountName?.let { name ->
+                            Text(
+                                text = name,
+                                style = MaterialTheme.typography.bodyLarge,
+                                color = MaterialTheme.colorScheme.primary,
+                            )
+                        }
+                        account.iban?.let { iban ->
+                            Text(
+                                text = stringResource(Res.string.iban_label, maskIban(iban)),
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.primary,
+                            )
+                        }
+                        account.currency?.let { currency ->
+                            Text(
+                                text = "Currency: $currency",
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.primary,
+                            )
+                        }
+                    }
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        TextButton(
+            onClick = onDone,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                text = stringResource(Res.string.done),
+                style = MaterialTheme.typography.titleMedium,
+            )
+        }
+    }
+}
+
+@Composable
+private fun ErrorStep(
+    errorMessage: String?,
+    onRetry: () -> Unit,
+    onBack: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Spacer(modifier = Modifier.height(32.dp))
+
+        Icon(
+            imageVector = Icons.Default.Close,
+            contentDescription = null,
+            modifier = Modifier.size(72.dp),
+            tint = MaterialTheme.colorScheme.error,
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        Text(
+            text = stringResource(Res.string.bank_auth_error),
+            style = MaterialTheme.typography.headlineSmall,
+            color = MaterialTheme.colorScheme.primary,
+            textAlign = TextAlign.Center,
+        )
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        Text(
+            text = stringResource(Res.string.bank_auth_error_description),
+            style = MaterialTheme.typography.bodyMedium,
+            color = MaterialTheme.colorScheme.primary,
+            textAlign = TextAlign.Center,
+        )
+
+        Spacer(modifier = Modifier.weight(1f))
+
+        TextButton(
+            onClick = onRetry,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                text = stringResource(Res.string.retry),
+                style = MaterialTheme.typography.titleMedium,
+            )
+        }
+
+        TextButton(
+            onClick = onBack,
+            modifier = Modifier.fillMaxWidth(),
+        ) {
+            Text(
+                text = stringResource(Res.string.back),
+                style = MaterialTheme.typography.titleMedium,
+            )
+        }
+    }
+}
+
+private fun maskIban(iban: String): String {
+    if (iban.length <= 8) return iban
+    val visibleStart = iban.take(4)
+    val visibleEnd = iban.takeLast(4)
+    val maskedMiddle = "*".repeat(iban.length - 8)
+    return "$visibleStart$maskedMiddle$visibleEnd"
+}
+
+@Composable
+private fun Card(
+    modifier: Modifier = Modifier,
+    content: @Composable () -> Unit,
+) {
+    androidx.compose.material3.Card(
+        modifier = modifier,
+    ) {
+        content()
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/banklinking/BankLinkingState.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/banklinking/BankLinkingState.kt
@@ -1,0 +1,87 @@
+package com.banko.app.ui.screens.banklinking
+
+import com.banko.app.api.dto.bankoApi.BankAccountSummaryDto
+import com.banko.app.api.dto.bankoApi.BankAuthorizationStatus
+import com.banko.app.api.dto.bankoApi.BankAuthDto
+import com.banko.app.api.dto.bankoApi.GoCardlessInstitutionDto
+import com.banko.app.api.dto.bankoApi.LinkedBankAccount
+
+enum class BankLinkingStep {
+    CountrySelection,
+    BankSelection,
+    Authorizing,
+    Processing,
+    Success,
+    Error,
+}
+
+data class Country(
+    val code: String,
+    val name: String,
+)
+
+val popularCountries = listOf(
+    Country("NO", "Norway"),
+    Country("SE", "Sweden"),
+    Country("DE", "Germany"),
+    Country("GB", "United Kingdom"),
+    Country("FR", "France"),
+    Country("ES", "Spain"),
+    Country("NL", "Netherlands"),
+    Country("FI", "Finland"),
+    Country("DK", "Denmark"),
+    Country("AT", "Austria"),
+    Country("IT", "Italy"),
+    Country("PL", "Poland"),
+)
+
+val allCountries = listOf(
+    Country("AT", "Austria"),
+    Country("BE", "Belgium"),
+    Country("BG", "Bulgaria"),
+    Country("HR", "Croatia"),
+    Country("CY", "Cyprus"),
+    Country("CZ", "Czech Republic"),
+    Country("DK", "Denmark"),
+    Country("EE", "Estonia"),
+    Country("FI", "Finland"),
+    Country("FR", "France"),
+    Country("DE", "Germany"),
+    Country("GR", "Greece"),
+    Country("HU", "Hungary"),
+    Country("IE", "Ireland"),
+    Country("IT", "Italy"),
+    Country("LV", "Latvia"),
+    Country("LT", "Lithuania"),
+    Country("LU", "Luxembourg"),
+    Country("MT", "Malta"),
+    Country("NL", "Netherlands"),
+    Country("NO", "Norway"),
+    Country("PL", "Poland"),
+    Country("PT", "Portugal"),
+    Country("RO", "Romania"),
+    Country("SK", "Slovakia"),
+    Country("SI", "Slovenia"),
+    Country("ES", "Spain"),
+    Country("SE", "Sweden"),
+    Country("GB", "United Kingdom"),
+)
+
+data class BankLinkingScreenState(
+    val currentStep: BankLinkingStep = BankLinkingStep.CountrySelection,
+    val selectedCountry: Country? = null,
+    val institutions: List<GoCardlessInstitutionDto> = emptyList(),
+    val selectedInstitution: GoCardlessInstitutionDto? = null,
+    val authUrl: String? = null,
+    val requisitionId: String? = null,
+    val bankAuthorizationId: String? = null,
+    val linkedAccounts: List<LinkedBankAccount> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: String? = null,
+)
+
+data class SettingsBankLinkingState(
+    val bankAuthorizations: List<BankAuthDto> = emptyList(),
+    val isLoading: Boolean = false,
+    val error: String? = null,
+)

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/banklinking/BankLinkingViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/banklinking/BankLinkingViewModel.kt
@@ -1,0 +1,268 @@
+package com.banko.app.ui.screens.banklinking
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.banko.app.api.dto.bankoApi.BankAuthorizationStatus
+import com.banko.app.api.dto.bankoApi.GetBankAuthorizationsResponse
+import com.banko.app.api.services.BankoApiService
+import com.banko.app.api.utils.Result
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+
+class BankLinkingViewModel(
+    private val apiService: BankoApiService,
+) : ViewModel() {
+
+    private val _screenState = MutableStateFlow(BankLinkingScreenState())
+    val screenState: StateFlow<BankLinkingScreenState> = _screenState
+
+    private val _settingsBankState = MutableStateFlow(SettingsBankLinkingState())
+    val settingsBankState: StateFlow<SettingsBankLinkingState> = _settingsBankState
+
+    init {
+        loadBankAuthorizations()
+    }
+
+    fun selectCountry(country: Country) {
+        _screenState.update {
+            it.copy(
+                selectedCountry = country,
+                currentStep = BankLinkingStep.BankSelection,
+                isLoading = true,
+                error = null,
+                institutions = emptyList(),
+            )
+        }
+        fetchInstitutions(country.code)
+    }
+
+    fun selectInstitution(institution: com.banko.app.api.dto.bankoApi.GoCardlessInstitutionDto) {
+        _screenState.update {
+            it.copy(
+                selectedInstitution = institution,
+                isLoading = true,
+                error = null,
+            )
+        }
+        createEndUserAgreement(institution.id)
+    }
+
+    fun onWebViewRedirect(url: String) {
+        val currentState = _screenState.value
+        val reqId = currentState.requisitionId ?: return
+
+        _screenState.update {
+            it.copy(
+                currentStep = BankLinkingStep.Processing,
+                isLoading = true,
+                error = null,
+            )
+        }
+        callBankAuthCallback(reqId)
+    }
+
+    fun onWebViewBack() {
+        _screenState.update {
+            it.copy(
+                currentStep = BankLinkingStep.BankSelection,
+                authUrl = null,
+                selectedInstitution = null,
+                error = null,
+            )
+        }
+    }
+
+    fun onWebViewError() {
+        _screenState.update {
+            it.copy(
+                currentStep = BankLinkingStep.Error,
+                error = "bank_auth_error",
+                isLoading = false,
+            )
+        }
+    }
+
+    fun retry() {
+        val state = _screenState.value
+        when (state.currentStep) {
+            BankLinkingStep.Error -> {
+                if (state.selectedInstitution != null) {
+                    _screenState.update {
+                        it.copy(
+                            currentStep = BankLinkingStep.BankSelection,
+                            isLoading = false,
+                            error = null,
+                            authUrl = null,
+                        )
+                    }
+                } else {
+                    _screenState.update {
+                        it.copy(
+                            currentStep = BankLinkingStep.CountrySelection,
+                            isLoading = false,
+                            error = null,
+                            selectedCountry = null,
+                        )
+                    }
+                }
+            }
+            else -> {}
+        }
+    }
+
+    fun done() {
+        _screenState.update {
+            BankLinkingScreenState()
+        }
+        loadBankAuthorizations()
+    }
+
+    fun goBack() {
+        val state = _screenState.value
+        when (state.currentStep) {
+            BankLinkingStep.BankSelection -> {
+                _screenState.update {
+                    it.copy(
+                        currentStep = BankLinkingStep.CountrySelection,
+                        selectedCountry = null,
+                        institutions = emptyList(),
+                        error = null,
+                    )
+                }
+            }
+            BankLinkingStep.CountrySelection -> {}
+            else -> {}
+        }
+    }
+
+    fun clearError() {
+        _screenState.update { it.copy(error = null) }
+    }
+
+    fun reAuthorize(institutionId: String) {
+        _screenState.update {
+            it.copy(
+                currentStep = BankLinkingStep.Authorizing,
+                isLoading = true,
+                error = null,
+            )
+        }
+        createEndUserAgreement(institutionId)
+    }
+
+    private fun fetchInstitutions(countryCode: String) {
+        viewModelScope.launch {
+            when (val result = apiService.getInstitutions(countryCode)) {
+                is Result.Success -> {
+                    _screenState.update {
+                        it.copy(
+                            institutions = result.value,
+                            isLoading = false,
+                        )
+                    }
+                }
+                is Result.Error -> {
+                    _screenState.update {
+                        it.copy(
+                            isLoading = false,
+                            error = "Failed to load banks. Please try again.",
+                            currentStep = BankLinkingStep.Error,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private fun createEndUserAgreement(institutionId: String) {
+        viewModelScope.launch {
+            when (val result = apiService.upsertEndUserAgreement(institutionId)) {
+                is Result.Success -> {
+                    val response = result.value
+                    _screenState.update {
+                        it.copy(
+                            authUrl = response.link,
+                            requisitionId = response.requisitionId,
+                            bankAuthorizationId = response.bankAuthorizationId,
+                            currentStep = BankLinkingStep.Authorizing,
+                            isLoading = false,
+                        )
+                    }
+                }
+                is Result.Error -> {
+                    _screenState.update {
+                        it.copy(
+                            isLoading = false,
+                            error = "Failed to start bank authorization. Please try again.",
+                            currentStep = BankLinkingStep.Error,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private fun callBankAuthCallback(requisitionId: String) {
+        viewModelScope.launch {
+            when (val result = apiService.bankAuthCallback(requisitionId)) {
+                is Result.Success -> {
+                    val response = result.value
+                    if (response.status == BankAuthorizationStatus.Linked) {
+                        _screenState.update {
+                            it.copy(
+                                currentStep = BankLinkingStep.Success,
+                                linkedAccounts = response.linkedAccounts,
+                                isLoading = false,
+                                error = null,
+                            )
+                        }
+                    } else {
+                        _screenState.update {
+                            it.copy(
+                                currentStep = BankLinkingStep.Error,
+                                error = "Account linking was not completed. Status: ${response.status}",
+                                isLoading = false,
+                            )
+                        }
+                    }
+                }
+                is Result.Error -> {
+                    _screenState.update {
+                        it.copy(
+                            currentStep = BankLinkingStep.Error,
+                            error = "Failed to complete bank authorization. Please try again.",
+                            isLoading = false,
+                        )
+                    }
+                }
+            }
+        }
+    }
+
+    private fun loadBankAuthorizations() {
+        viewModelScope.launch {
+            _settingsBankState.update { it.copy(isLoading = true) }
+            when (val result = apiService.getBankAuthorizations()) {
+                is Result.Success -> {
+                    _settingsBankState.update {
+                        it.copy(
+                            bankAuthorizations = result.value.bankAuthorizations,
+                            isLoading = false,
+                        )
+                    }
+                }
+                is Result.Error -> {
+                    _settingsBankState.update {
+                        it.copy(
+                            isLoading = false,
+                            error = "Failed to load bank authorizations.",
+                        )
+                    }
+                }
+            }
+        }
+    }
+}

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/navigation/RootComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/navigation/RootComponent.kt
@@ -8,6 +8,7 @@ import com.arkivanov.decompose.router.stack.childStack
 import com.arkivanov.decompose.router.stack.pop
 import com.banko.app.api.auth.SessionManager
 import com.banko.app.ui.models.Transaction
+import com.banko.app.ui.screens.banklinking.BankLinkingComponent
 import com.banko.app.ui.screens.details.DetailsComponent
 import com.banko.app.ui.screens.home.HomeComponent
 import com.banko.app.ui.screens.profile.ProfileComponent
@@ -54,12 +55,23 @@ class RootComponent(
                 SettingsComponent(
                     componentContext = context,
                     onNavigateToProfile = { navigation.bringToFront(Configuration.Profile) },
+                    onNavigateToBankLinking = { navigation.bringToFront(Configuration.BankLinking()) },
+                    onReAuthorize = { institutionId ->
+                        navigation.bringToFront(Configuration.BankLinking(institutionId = institutionId))
+                    },
                 )
             )
             is Configuration.Profile -> Child.Profile(
                 ProfileComponent(
                     componentContext = context,
                     onGoBack = { navigation.pop() },
+                )
+            )
+            is Configuration.BankLinking -> Child.BankLinking(
+                BankLinkingComponent(
+                    componentContext = context,
+                    onGoBack = { navigation.pop() },
+                    institutionId = config.institutionId,
                 )
             )
         }
@@ -70,6 +82,7 @@ class RootComponent(
         data class Details(val component: DetailsComponent) : Child()
         data class Settings(val component: SettingsComponent) : Child()
         data class Profile(val component: ProfileComponent) : Child()
+        data class BankLinking(val component: BankLinkingComponent) : Child()
     }
 
     @Serializable
@@ -86,5 +99,10 @@ class RootComponent(
 
         @Serializable
         data object Profile : Configuration()
+
+        @Serializable
+        data class BankLinking(
+            val institutionId: String? = null,
+        ) : Configuration()
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/SettingsComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/SettingsComponent.kt
@@ -7,4 +7,6 @@ import org.koin.compose.viewmodel.koinViewModel
 class SettingsComponent(
     componentContext: ComponentContext,
     val onNavigateToProfile: () -> Unit = {},
+    val onNavigateToBankLinking: () -> Unit = {},
+    val onReAuthorize: (institutionId: String) -> Unit = {},
 ): ComponentContext by componentContext

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/SettingsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/SettingsScreen.kt
@@ -1,12 +1,13 @@
 package com.banko.app.ui.screens.settings
 
 import androidx.compose.foundation.clickable
-import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.heightIn
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
@@ -32,6 +33,10 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import banko.composeapp.generated.resources.Res
+import banko.composeapp.generated.resources.account_balance
+import banko.composeapp.generated.resources.add_new_bank
+import banko.composeapp.generated.resources.add_new_bank_description
+import banko.composeapp.generated.resources.banks
 import banko.composeapp.generated.resources.currency
 import banko.composeapp.generated.resources.expense_tags
 import banko.composeapp.generated.resources.expense_tags_title
@@ -39,11 +44,13 @@ import banko.composeapp.generated.resources.general
 import banko.composeapp.generated.resources.ic_arrow_right
 import banko.composeapp.generated.resources.ic_currency
 import banko.composeapp.generated.resources.ic_expense_tags
+import banko.composeapp.generated.resources.linked_banks
 import banko.composeapp.generated.resources.profile
 import banko.composeapp.generated.resources.settings
 import com.banko.app.domain.model.currencyDisplayForCode
 import com.banko.app.ui.components.SettingsCard
 import com.banko.app.ui.screens.settings.bottomsheets.ExpenseTagsBottomSheetContent
+import com.banko.app.ui.screens.settings.bottomsheets.LinkedBanksBottomSheetContent
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
 import org.koin.compose.viewmodel.koinViewModel
@@ -71,6 +78,19 @@ fun SettingsScreen(component: SettingsComponent) {
                 onTagDelete = { viewModel.deleteExpenseTag(it) },
                 clearError = { viewModel.clearError() },
                 onClose = { currentBottomSheet = BottomSheetType.NONE }
+            )
+        }
+    }
+
+    if (currentBottomSheet == BottomSheetType.LINKED_BANKS) {
+        ModalBottomSheet(
+            onDismissRequest = { currentBottomSheet = BottomSheetType.NONE },
+            sheetState = sheetState
+        ) {
+            LinkedBanksBottomSheetContent(
+                screenState = screenState,
+                onReAuthorize = { institutionId -> component.onReAuthorize(institutionId) },
+                onClose = { currentBottomSheet = BottomSheetType.NONE },
             )
         }
     }
@@ -191,6 +211,31 @@ fun SettingsScreen(component: SettingsComponent) {
             Row {
                 Text(
                     modifier = Modifier.padding(top = 24.dp, bottom = 16.dp),
+                    text = stringResource(Res.string.banks),
+                    color = MaterialTheme.colorScheme.primary,
+                    style = MaterialTheme.typography.titleSmall
+                )
+            }
+            Row {
+                SettingsCard(
+                    icon = Res.drawable.account_balance,
+                    title = Res.string.add_new_bank,
+                    description = Res.string.add_new_bank_description,
+                    onClick = component.onNavigateToBankLinking,
+                )
+            }
+            Spacer(modifier = Modifier.height(8.dp))
+            Row {
+                SettingsCard(
+                    icon = Res.drawable.account_balance,
+                    title = Res.string.linked_banks,
+                    description = Res.string.linked_banks,
+                    onClick = { currentBottomSheet = BottomSheetType.LINKED_BANKS },
+                )
+            }
+            Row {
+                Text(
+                    modifier = Modifier.padding(top = 24.dp, bottom = 16.dp),
                     text = stringResource(Res.string.expense_tags_title),
                     color = MaterialTheme.colorScheme.primary,
                     style = MaterialTheme.typography.titleSmall
@@ -210,5 +255,6 @@ fun SettingsScreen(component: SettingsComponent) {
 
 enum class BottomSheetType {
     EXPENSE_TAGS,
+    LINKED_BANKS,
     NONE
 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/SettingsScreenState.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/SettingsScreenState.kt
@@ -1,5 +1,6 @@
 package com.banko.app.ui.screens.settings
 
+import com.banko.app.api.dto.bankoApi.BankAuthDto
 import com.banko.app.domain.model.CurrencyInfo
 import com.banko.app.ui.models.ExpenseTag
 import com.banko.app.ui.utils.ErrorState
@@ -8,5 +9,7 @@ data class SettingsScreenState(
     val expenseTags: List<ExpenseTag> = emptyList(),
     val selectedCurrency: CurrencyInfo = CurrencyInfo("NOK", "Norwegian Krone", "kr"),
     val availableCurrencies: List<CurrencyInfo> = emptyList(),
+    val bankAuthorizations: List<BankAuthDto> = emptyList(),
+    val isLoadingBanks: Boolean = false,
     val error: ErrorState? = null,
 )

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/SettingsScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/SettingsScreenViewModel.kt
@@ -6,6 +6,8 @@ import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.banko.app.ApiExpenseTagRepository
 import com.banko.app.DatabaseExpenseTagRepository
+import com.banko.app.api.services.BankoApiService
+import com.banko.app.api.utils.Result
 import com.banko.app.database.Entities.toModelItem
 import com.banko.app.domain.CurrencyPreferences
 import com.banko.app.domain.model.CurrencyInfo
@@ -26,6 +28,7 @@ class SettingsScreenViewModel(
     private val dbRepository: DatabaseExpenseTagRepository,
     private val apiRepository: ApiExpenseTagRepository,
     private val currencyPreferences: CurrencyPreferences,
+    private val apiService: BankoApiService,
 ) : ViewModel() {
     private val _screenState = MutableStateFlow(SettingsScreenState())
     val screenState: StateFlow<SettingsScreenState> = _screenState
@@ -33,6 +36,7 @@ class SettingsScreenViewModel(
     init {
         getExpenseTags()
         loadCurrencyPreferences()
+        loadBankAuthorizations()
     }
 
     private fun getExpenseTags() {
@@ -118,5 +122,26 @@ class SettingsScreenViewModel(
 
     fun clearError() {
         _screenState.update { it.copy(error = null) }
+    }
+
+    fun loadBankAuthorizations() {
+        viewModelScope.launch {
+            _screenState.update { it.copy(isLoadingBanks = true) }
+            when (val result = apiService.getBankAuthorizations()) {
+                is Result.Success -> {
+                    _screenState.update {
+                        it.copy(
+                            bankAuthorizations = result.value.bankAuthorizations,
+                            isLoadingBanks = false,
+                        )
+                    }
+                }
+                is Result.Error -> {
+                    _screenState.update {
+                        it.copy(isLoadingBanks = false)
+                    }
+                }
+            }
+        }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/bottomsheets/LinkedBanksBottomSheetContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/bottomsheets/LinkedBanksBottomSheetContent.kt
@@ -25,8 +25,11 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.unit.dp
+import com.banko.app.ui.theme.Amber
+import com.banko.app.ui.theme.Crimson
+import com.banko.app.ui.theme.Firebrick
+import com.banko.app.ui.theme.MediumSeaGreen
 import banko.composeapp.generated.resources.Res
 import banko.composeapp.generated.resources.error_status
 import banko.composeapp.generated.resources.expired
@@ -197,10 +200,10 @@ private fun StatusBadge(
     status: BankAuthorizationStatus,
 ) {
     val (text, color) = when (status) {
-        BankAuthorizationStatus.Linked -> stringResource(Res.string.linked) to Color(0xFF4CAF50)
-        BankAuthorizationStatus.Processing -> stringResource(Res.string.processing) to Color(0xFFFFC107)
-        BankAuthorizationStatus.Expired -> stringResource(Res.string.expired) to Color(0xFFF44336)
-        BankAuthorizationStatus.Error -> stringResource(Res.string.error_status) to Color(0xFFF44336)
+        BankAuthorizationStatus.Linked -> stringResource(Res.string.linked) to MediumSeaGreen
+        BankAuthorizationStatus.Processing -> stringResource(Res.string.processing) to Amber
+        BankAuthorizationStatus.Expired -> stringResource(Res.string.expired) to Firebrick
+        BankAuthorizationStatus.Error -> stringResource(Res.string.error_status) to Crimson
     }
 
     Row(

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/bottomsheets/LinkedBanksBottomSheetContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/bottomsheets/LinkedBanksBottomSheetContent.kt
@@ -136,7 +136,7 @@ private fun BankAuthorizationRow(
             verticalAlignment = Alignment.CenterVertically,
         ) {
             BankLogo(
-                logoUrl = null,
+                logoUrl = auth.institutionLogoUrl,
                 bankName = auth.institutionName,
                 size = 40,
             )

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/bottomsheets/LinkedBanksBottomSheetContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/bottomsheets/LinkedBanksBottomSheetContent.kt
@@ -1,0 +1,232 @@
+package com.banko.app.ui.screens.settings.bottomsheets
+
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.itemsIndexed
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Close
+import androidx.compose.material3.CircularProgressIndicator
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.unit.dp
+import banko.composeapp.generated.resources.Res
+import banko.composeapp.generated.resources.error_status
+import banko.composeapp.generated.resources.expired
+import banko.composeapp.generated.resources.expense_tags_bottom_sheet_button_close
+import banko.composeapp.generated.resources.iban_label
+import banko.composeapp.generated.resources.linked
+import banko.composeapp.generated.resources.linked_banks
+import banko.composeapp.generated.resources.no_linked_banks
+import banko.composeapp.generated.resources.processing
+import banko.composeapp.generated.resources.re_authorize
+import com.banko.app.api.dto.bankoApi.BankAuthorizationStatus
+import com.banko.app.api.dto.bankoApi.BankAuthDto
+import com.banko.app.ui.components.BankLogo
+import com.banko.app.ui.screens.settings.SettingsScreenState
+import org.jetbrains.compose.resources.painterResource
+import org.jetbrains.compose.resources.stringResource
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun LinkedBanksBottomSheetContent(
+    screenState: SettingsScreenState,
+    onReAuthorize: (String) -> Unit,
+    onClose: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(horizontal = 16.dp)
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            Text(
+                text = stringResource(Res.string.linked_banks),
+                style = MaterialTheme.typography.titleMedium,
+                color = MaterialTheme.colorScheme.primary,
+                modifier = Modifier.weight(1f),
+            )
+            IconButton(onClick = onClose) {
+                Icon(
+                    imageVector = Icons.Default.Close,
+                    contentDescription = stringResource(Res.string.expense_tags_bottom_sheet_button_close),
+                    tint = MaterialTheme.colorScheme.primary,
+                )
+            }
+        }
+
+        Spacer(modifier = Modifier.height(8.dp))
+
+        when {
+            screenState.isLoadingBanks -> {
+                Row(
+                    modifier = Modifier.fillMaxWidth().padding(vertical = 24.dp),
+                    horizontalArrangement = androidx.compose.foundation.layout.Arrangement.Center,
+                ) {
+                    CircularProgressIndicator(modifier = Modifier.size(32.dp))
+                }
+            }
+            screenState.bankAuthorizations.isEmpty() -> {
+                Text(
+                    text = stringResource(Res.string.no_linked_banks),
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    modifier = Modifier.padding(vertical = 24.dp),
+                )
+            }
+            else -> {
+                LazyColumn(
+                    modifier = Modifier.fillMaxWidth(),
+                ) {
+                    itemsIndexed(screenState.bankAuthorizations) { index, auth ->
+                        if (index > 0) {
+                            HorizontalDivider(
+                                modifier = Modifier.padding(vertical = 4.dp),
+                                color = MaterialTheme.colorScheme.outlineVariant,
+                            )
+                        }
+                        BankAuthorizationRow(
+                            auth = auth,
+                            onReAuthorize = { onReAuthorize(auth.institutionId ?: "") },
+                        )
+                    }
+                }
+            }
+        }
+
+        Spacer(modifier = Modifier.height(24.dp))
+    }
+}
+
+@Composable
+private fun BankAuthorizationRow(
+    auth: BankAuthDto,
+    onReAuthorize: () -> Unit,
+) {
+    Column(
+        modifier = Modifier
+            .fillMaxWidth()
+            .padding(vertical = 8.dp),
+    ) {
+        Row(
+            modifier = Modifier.fillMaxWidth(),
+            verticalAlignment = Alignment.CenterVertically,
+        ) {
+            BankLogo(
+                logoUrl = null,
+                bankName = auth.institutionName,
+                size = 40,
+            )
+            Spacer(modifier = Modifier.width(12.dp))
+            Column(modifier = Modifier.weight(1f)) {
+                Text(
+                    text = auth.institutionName ?: "",
+                    style = MaterialTheme.typography.bodyLarge,
+                    color = MaterialTheme.colorScheme.onSurface,
+                )
+                StatusBadge(status = auth.status)
+            }
+            if (auth.status == BankAuthorizationStatus.Expired || auth.status == BankAuthorizationStatus.Error) {
+                TextButton(onClick = onReAuthorize) {
+                    Text(text = stringResource(Res.string.re_authorize))
+                }
+            }
+        }
+        if (auth.accounts.isNotEmpty()) {
+            Spacer(modifier = Modifier.height(8.dp))
+            auth.accounts.forEach { account ->
+                Row(
+                    modifier = Modifier
+                        .fillMaxWidth()
+                        .padding(start = 52.dp, top = 2.dp, bottom = 2.dp),
+                    verticalAlignment = Alignment.CenterVertically,
+                ) {
+                    Column(modifier = Modifier.weight(1f)) {
+                        account.accountName?.let { name ->
+                            Text(
+                                text = name,
+                                style = MaterialTheme.typography.bodyMedium,
+                                color = MaterialTheme.colorScheme.onSurface,
+                            )
+                        }
+                        Row {
+                            account.iban?.let { iban ->
+                                Text(
+                                    text = stringResource(Res.string.iban_label, maskIban(iban)),
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                            account.currency?.let { currency ->
+                                Text(
+                                    text = " · $currency",
+                                    style = MaterialTheme.typography.bodySmall,
+                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                )
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+@Composable
+private fun StatusBadge(
+    status: BankAuthorizationStatus,
+) {
+    val (text, color) = when (status) {
+        BankAuthorizationStatus.Linked -> stringResource(Res.string.linked) to Color(0xFF4CAF50)
+        BankAuthorizationStatus.Processing -> stringResource(Res.string.processing) to Color(0xFFFFC107)
+        BankAuthorizationStatus.Expired -> stringResource(Res.string.expired) to Color(0xFFF44336)
+        BankAuthorizationStatus.Error -> stringResource(Res.string.error_status) to Color(0xFFF44336)
+    }
+
+    Row(
+        verticalAlignment = Alignment.CenterVertically,
+        modifier = Modifier
+            .clip(CircleShape)
+            .padding(horizontal = 4.dp),
+    ) {
+        androidx.compose.foundation.Canvas(
+            modifier = Modifier.size(8.dp),
+        ) {
+            drawCircle(color = color)
+        }
+        Spacer(modifier = Modifier.width(4.dp))
+        Text(
+            text = text,
+            style = MaterialTheme.typography.labelSmall,
+            color = color,
+        )
+    }
+}
+
+private fun maskIban(iban: String): String {
+    if (iban.length <= 8) return iban
+    val visibleStart = iban.take(4)
+    val visibleEnd = iban.takeLast(4)
+    val maskedMiddle = "*".repeat(iban.length - 8)
+    return "$visibleStart$maskedMiddle$visibleEnd"
+}

--- a/composeApp/src/iosMain/kotlin/com/banko/app/ui/components/BankLinkingWebView.ios.kt
+++ b/composeApp/src/iosMain/kotlin/com/banko/app/ui/components/BankLinkingWebView.ios.kt
@@ -1,0 +1,66 @@
+package com.banko.app.ui.components
+
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.interop.UIKitView
+import kotlinx.cinterop.ExperimentalForeignApi
+import platform.CoreGraphics.CGRectMake
+import platform.Foundation.NSURL
+import platform.Foundation.NSURLRequest
+import platform.WebKit.WKNavigationAction
+import platform.WebKit.WKNavigationActionPolicy
+import platform.WebKit.WKNavigationDelegateProtocol
+import platform.WebKit.WKWebView
+import platform.WebKit.WKWebViewConfiguration
+import platform.darwin.NSObject
+
+private const val REDIRECT_PREFIX = "Banko://"
+
+@OptIn(ExperimentalForeignApi::class)
+@Composable
+actual fun BankLinkingWebView(
+    url: String,
+    onRedirectDetected: (url: String) -> Unit,
+    onBack: () -> Unit,
+    modifier: Modifier,
+) {
+    val configuration = remember { WKWebViewConfiguration() }
+    val navigationDelegate = remember {
+        object : NSObject(), WKNavigationDelegateProtocol {
+            override fun webView(
+                webView: WKWebView,
+                decidePolicyForNavigationAction: WKNavigationAction,
+                decisionHandler: (WKNavigationActionPolicy) -> Unit
+            ) {
+                val requestUrl = decidePolicyForNavigationAction.request.URL?.absoluteString ?: ""
+                if (requestUrl.startsWith(REDIRECT_PREFIX, ignoreCase = true)) {
+                    onRedirectDetected(requestUrl)
+                    decisionHandler(WKNavigationActionPolicy.WKNavigationActionPolicyCancel)
+                } else {
+                    decisionHandler(WKNavigationActionPolicy.WKNavigationActionPolicyAllow)
+                }
+            }
+        }
+    }
+
+    UIKitView(
+        factory = {
+            WKWebView(
+                frame = CGRectMake(0.0, 0.0, 0.0, 0.0),
+                configuration = configuration
+            ).apply {
+                setNavigationDelegate(navigationDelegate)
+                loadRequest(NSURLRequest(uRL = NSURL(string = url)))
+            }
+        },
+        modifier = modifier.fillMaxSize(),
+        update = { webView ->
+            val currentUrl = webView.URL?.absoluteString
+            if (currentUrl != url) {
+                webView.loadRequest(NSURLRequest(uRL = NSURL(string = url)))
+            }
+        }
+    )
+}


### PR DESCRIPTION
## What
- Add bank linking feature with multi-step flow: country selection → bank selection with search → WebView authorization → processing → success/error
- Add institution logo support for linked banks in settings screen
- Add re-authorize flow for expired/errored bank connections
- Add deep link support for Banko://bank-auth-callback redirect
- Add WebView implementation for Android (WebViewClient) and iOS (WKWebView)
- Add bank linking section to settings with "Add New Bank" and "Linked Banks" cards
- Add status badges with app palette colors (Linked, Processing, Expired, Error)
- Add all user-facing string resources for the bank linking flow

## Why
- Users need to link their bank accounts to enable transaction syncing via GoCardless
- The multi-step flow provides a guided UX for selecting country, bank, and authorizing via the bank's own authentication
- Re-authorize support lets users recover from expired or errored connections without re-linking from scratch
- Institution logos improve recognition and trust in the linked banks list
- Deep links ensure the WebView redirect returns to the app correctly on both platforms
- Removing mocks ensures the feature only uses real API calls in production

