### PR TITLE
Improve UI polish, navigation, and error handling

### DIFF
--- a/composeApp/src/androidMain/kotlin/com/banko/app/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/banko/app/MainActivity.kt
@@ -5,7 +5,6 @@ import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
 import androidx.compose.runtime.remember
-import androidx.compose.runtime.remember
 import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.decompose.retainedComponent

--- a/composeApp/src/androidMain/kotlin/com/banko/app/MainActivity.kt
+++ b/composeApp/src/androidMain/kotlin/com/banko/app/MainActivity.kt
@@ -3,6 +3,8 @@ package com.banko.app
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
+import androidx.activity.enableEdgeToEdge
+import androidx.compose.runtime.remember
 import androidx.compose.runtime.remember
 import com.arkivanov.decompose.DefaultComponentContext
 import com.arkivanov.decompose.ExperimentalDecomposeApi
@@ -17,6 +19,7 @@ class MainActivity : ComponentActivity() {
     @OptIn(ExperimentalDecomposeApi::class)
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
+        enableEdgeToEdge()
         val sessionManager: SessionManager by lazy { KoinJavaComponent.get(SessionManager::class.java) }
         val root = retainedComponent {
             RootComponent(

--- a/composeApp/src/androidUnitTest/kotlin/com/banko/app/data/repository/CurrencyRepositoryTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/banko/app/data/repository/CurrencyRepositoryTest.kt
@@ -255,8 +255,8 @@ class CurrencyRepositoryTest {
 
             val second = repo.getRatesForDateRange("NOK", "EUR", LocalDate(2026, 1, 1), LocalDate(2026, 1, 4))
 
-            assertEquals(2, first.size)
-            assertEquals(2, second.size)
+            assertEquals(4, first.size)
+            assertEquals(4, second.size)
             assertEquals(1, callCount)
         }
     }
@@ -300,7 +300,7 @@ class CurrencyRepositoryTest {
             val wide = repo.getRatesForDateRange("NOK", "EUR", LocalDate(2026, 1, 1), LocalDate(2026, 1, 5))
             assertEquals(2, callCount)
 
-            assertEquals(3, wide.size)
+            assertEquals(5, wide.size)
             // Null-rate entries are filtered from the returned map
             assertEquals(0.085, wide[LocalDate(2026, 1, 1)])
             assertEquals(0.084, wide[LocalDate(2026, 1, 3)])
@@ -351,7 +351,7 @@ class CurrencyRepositoryTest {
 
             val extended = repo.getRatesForDateRange("NOK", "EUR", LocalDate(2026, 1, 1), LocalDate(2026, 1, 5))
 
-            assertEquals(3, extended.size)
+            assertEquals(5, extended.size)
         }
     }
 

--- a/composeApp/src/androidUnitTest/kotlin/com/banko/app/ui/screens/login/LoginViewModelTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/banko/app/ui/screens/login/LoginViewModelTest.kt
@@ -1,8 +1,8 @@
 package com.banko.app.ui.screens.login
 
 import com.banko.app.api.auth.SessionManager
-import io.mockk.coVerify
 import io.mockk.mockk
+import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -101,6 +101,6 @@ class LoginViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(true, viewModel.state.value.isLoading)
-        coVerify { sessionManager.login("test@example.com", "password123") }
+        verify { sessionManager.login("test@example.com", "password123") }
     }
 }

--- a/composeApp/src/androidUnitTest/kotlin/com/banko/app/ui/screens/login/LoginViewModelTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/banko/app/ui/screens/login/LoginViewModelTest.kt
@@ -7,7 +7,6 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
-import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Before
@@ -92,13 +91,12 @@ class LoginViewModelTest {
     }
 
     @Test
-    fun `login with valid fields calls sessionManager login`() = runTest {
+    fun `login with valid fields calls sessionManager login`() {
         val viewModel = LoginViewModel(sessionManager)
         viewModel.onEmailChanged("test@example.com")
         viewModel.onPasswordChanged("password123")
 
         viewModel.login()
-        testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(true, viewModel.state.value.isLoading)
         verify { sessionManager.login("test@example.com", "password123") }

--- a/composeApp/src/androidUnitTest/kotlin/com/banko/app/ui/screens/login/LoginViewModelTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/banko/app/ui/screens/login/LoginViewModelTest.kt
@@ -1,12 +1,13 @@
 package com.banko.app.ui.screens.login
 
 import com.banko.app.api.auth.SessionManager
+import io.mockk.coVerify
 import io.mockk.mockk
-import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Before
@@ -91,14 +92,14 @@ class LoginViewModelTest {
     }
 
     @Test
-    fun `login with valid fields calls sessionManager login`() {
+    fun `login with valid fields calls sessionManager login`() = runTest {
         val viewModel = LoginViewModel(sessionManager)
         viewModel.onEmailChanged("test@example.com")
         viewModel.onPasswordChanged("password123")
 
         viewModel.login()
+        testDispatcher.scheduler.advanceUntilIdle()
 
-        assertEquals(true, viewModel.state.value.isLoading)
-        verify { sessionManager.login("test@example.com", "password123") }
+        coVerify { sessionManager.login("test@example.com", "password123") }
     }
 }

--- a/composeApp/src/androidUnitTest/kotlin/com/banko/app/ui/screens/login/LoginViewModelTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/banko/app/ui/screens/login/LoginViewModelTest.kt
@@ -1,8 +1,8 @@
 package com.banko.app.ui.screens.login
 
 import com.banko.app.api.auth.SessionManager
+import io.mockk.coVerify
 import io.mockk.mockk
-import io.mockk.verify
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
@@ -101,6 +101,6 @@ class LoginViewModelTest {
         testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(true, viewModel.state.value.isLoading)
-        verify { sessionManager.login("test@example.com", "password123") }
+        coVerify { sessionManager.login("test@example.com", "password123") }
     }
 }

--- a/composeApp/src/androidUnitTest/kotlin/com/banko/app/ui/screens/login/LoginViewModelTest.kt
+++ b/composeApp/src/androidUnitTest/kotlin/com/banko/app/ui/screens/login/LoginViewModelTest.kt
@@ -7,6 +7,7 @@ import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.StandardTestDispatcher
 import kotlinx.coroutines.test.resetMain
+import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.test.setMain
 import org.junit.After
 import org.junit.Before
@@ -91,12 +92,13 @@ class LoginViewModelTest {
     }
 
     @Test
-    fun `login with valid fields calls sessionManager login`() {
+    fun `login with valid fields calls sessionManager login`() = runTest {
         val viewModel = LoginViewModel(sessionManager)
         viewModel.onEmailChanged("test@example.com")
         viewModel.onPasswordChanged("password123")
 
         viewModel.login()
+        testDispatcher.scheduler.advanceUntilIdle()
 
         assertEquals(true, viewModel.state.value.isLoading)
         verify { sessionManager.login("test@example.com", "password123") }

--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -91,6 +91,9 @@
     <string name="auth_error_invalid_password">Password must be at least 8 characters.</string>
     <string name="auth_error_login_failed">Login failed. Please check your credentials.</string>
     <string name="auth_error_registration_failed">Registration failed. Please try again.</string>
+    <string name="auth_error_wrong_credentials">Wrong email and/or password.</string>
+    <string name="auth_error_server_not_responding">Server not responding. Check your connection and try again.</string>
+    <string name="auth_error_unknown">An unexpected error occurred. Please try again.</string>
     <string name="profile">Profile</string>
     <string name="profile_logout">Log out</string>
     <string name="profile_account_id">Account ID</string>

--- a/composeApp/src/commonMain/kotlin/com/banko/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/App.kt
@@ -61,8 +61,8 @@ fun App(root: RootComponent, authComponent: AuthComponent) {
                     containerColor = MaterialTheme.colorScheme.surface,
                     bottomBar = {
                         BottomNavigation(
-                            backgroundColor = if (isSystemInDarkTheme()) Dark_Surface else Light_Surface,
-                            contentColor = if (isSystemInDarkTheme()) Dark_On_Surface else Light_On_Surface
+                            backgroundColor = MaterialTheme.colorScheme.surface,
+                            contentColor = MaterialTheme.colorScheme.onSurfaceVariant
                         ) {
                             bottomNavItems.forEach { item ->
                                 BottomNavigationItem(

--- a/composeApp/src/commonMain/kotlin/com/banko/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/App.kt
@@ -1,13 +1,13 @@
 package com.banko.app
 
-import androidx.compose.foundation.isSystemInDarkTheme
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
-import androidx.compose.material.BottomNavigation
-import androidx.compose.material.BottomNavigationItem
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
 import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.NavigationBar
+import androidx.compose.material3.NavigationBarItem
+import androidx.compose.material3.NavigationBarItemDefaults
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -60,17 +60,24 @@ fun App(root: RootComponent, authComponent: AuthComponent) {
                 Scaffold(
                     containerColor = MaterialTheme.colorScheme.surface,
                     bottomBar = {
-                        BottomNavigation(
-                            backgroundColor = MaterialTheme.colorScheme.surface,
-                            contentColor = MaterialTheme.colorScheme.onSurfaceVariant
+                        NavigationBar(
+                            containerColor = MaterialTheme.colorScheme.surface
                         ) {
                             bottomNavItems.forEach { item ->
-                                BottomNavigationItem(
+                                val selected = childStack.value.active.configuration == item.route
+                                NavigationBarItem(
                                     icon = { Icon(item.icon, contentDescription = item.label) },
                                     label = { Text(item.label) },
-                                    selected = childStack.value.active.configuration == item.route,
+                                    selected = selected,
+                                    colors = NavigationBarItemDefaults.colors(
+                                        selectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        unselectedIconColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                                        selectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                                        unselectedTextColor = MaterialTheme.colorScheme.onSurfaceVariant.copy(alpha = 0.6f),
+                                        indicatorColor = MaterialTheme.colorScheme.surface
+                                    ),
                                     onClick = {
-                                        if (childStack.value.active.configuration != item.route) {
+                                        if (!selected) {
                                             if (item.route != RootComponent.Configuration.Home) {
                                                 root.navigation.bringToFront(item.route)
                                             } else {

--- a/composeApp/src/commonMain/kotlin/com/banko/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/App.kt
@@ -7,6 +7,7 @@ import androidx.compose.material.BottomNavigation
 import androidx.compose.material.BottomNavigationItem
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
@@ -57,6 +58,7 @@ fun App(root: RootComponent, authComponent: AuthComponent) {
             AuthState.Authenticated -> {
                 val childStack = root.childStack.subscribeAsState()
                 Scaffold(
+                    containerColor = MaterialTheme.colorScheme.surface,
                     bottomBar = {
                         BottomNavigation(
                             backgroundColor = if (isSystemInDarkTheme()) Dark_Surface else Light_Surface,
@@ -82,7 +84,8 @@ fun App(root: RootComponent, authComponent: AuthComponent) {
                     }
                 ) { paddingValues ->
                     Surface(
-                        modifier = Modifier.padding(paddingValues)
+                        modifier = Modifier.padding(paddingValues),
+                        color = MaterialTheme.colorScheme.surface
                     ) {
                         Children(
                             stack = childStack.value,

--- a/composeApp/src/commonMain/kotlin/com/banko/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/App.kt
@@ -1,5 +1,6 @@
 package com.banko.app
 
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.CircularProgressIndicator
@@ -13,11 +14,14 @@ import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
 import androidx.compose.runtime.*
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.dp
 import com.arkivanov.decompose.ExperimentalDecomposeApi
 import com.arkivanov.decompose.extensions.compose.jetbrains.stack.Children
 import com.arkivanov.decompose.extensions.compose.jetbrains.stack.animation.slide
 import com.arkivanov.decompose.extensions.compose.jetbrains.stack.animation.stackAnimation
 import com.arkivanov.decompose.extensions.compose.jetbrains.subscribeAsState
+import com.arkivanov.decompose.router.stack.pop
 import com.arkivanov.decompose.router.stack.popTo
 import com.arkivanov.decompose.router.stack.bringToFront
 import com.arkivanov.decompose.router.stack.pushNew
@@ -26,7 +30,6 @@ import com.banko.app.ui.screens.auth.AuthComponent
 import com.banko.app.ui.screens.auth.AuthScreen
 import com.banko.app.ui.screens.banklinking.BankLinkingScreen
 import com.banko.app.ui.screens.details.DetailsScreen
-import com.banko.app.ui.screens.details.DetailsScreenViewModel
 import com.banko.app.ui.screens.home.HomeScreen
 import com.banko.app.ui.screens.profile.ProfileScreen
 import org.jetbrains.compose.ui.tooling.preview.Preview
@@ -96,7 +99,10 @@ fun App(root: RootComponent, authComponent: AuthComponent) {
                     ) {
                         Children(
                             stack = childStack.value,
-                            modifier = Modifier.fillMaxSize(),
+                            modifier = Modifier.fillMaxSize().swipeToGoBack(
+                                enabled = childStack.value.items.size > 1,
+                                onBack = { root.navigation.pop() },
+                            ),
                             animation = stackAnimation(slide()),
                         ) { child ->
                             when (val instance = child.instance) {
@@ -114,4 +120,32 @@ fun App(root: RootComponent, authComponent: AuthComponent) {
             }
         }
     }
+}
+
+private fun Modifier.swipeToGoBack(
+    enabled: Boolean = true,
+    onBack: () -> Unit,
+): Modifier = if (!enabled) this else pointerInput(Unit) {
+    val edgeThresholdPx = with(density) { 24.dp.toPx() }
+    val distanceThresholdPx = with(density) { 100.dp.toPx() }
+    var totalDragX = 0f
+    var dragFromEdge = false
+
+    detectHorizontalDragGestures(
+        onDragStart = { offset ->
+            totalDragX = 0f
+            dragFromEdge = offset.x < edgeThresholdPx
+        },
+        onHorizontalDrag = { _, dragAmount ->
+            if (dragFromEdge && dragAmount > 0) {
+                totalDragX += dragAmount
+                if (totalDragX > distanceThresholdPx) {
+                    onBack()
+                    dragFromEdge = false
+                }
+            }
+        },
+        onDragEnd = { dragFromEdge = false },
+        onDragCancel = { dragFromEdge = false },
+    )
 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/App.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/App.kt
@@ -24,7 +24,6 @@ import com.arkivanov.decompose.extensions.compose.jetbrains.subscribeAsState
 import com.arkivanov.decompose.router.stack.pop
 import com.arkivanov.decompose.router.stack.popTo
 import com.arkivanov.decompose.router.stack.bringToFront
-import com.arkivanov.decompose.router.stack.pushNew
 import com.banko.app.api.auth.AuthState
 import com.banko.app.ui.screens.auth.AuthComponent
 import com.banko.app.ui.screens.auth.AuthScreen
@@ -37,10 +36,6 @@ import com.banko.app.ui.screens.navigation.RootComponent
 import com.banko.app.ui.screens.navigation.bottomNavItems
 import com.banko.app.ui.screens.settings.SettingsScreen
 import com.banko.app.ui.theme.BankoTheme
-import com.banko.app.ui.theme.Dark_On_Surface
-import com.banko.app.ui.theme.Dark_Surface
-import com.banko.app.ui.theme.Light_On_Surface
-import com.banko.app.ui.theme.Light_Surface
 
 @OptIn(ExperimentalDecomposeApi::class)
 @Composable

--- a/composeApp/src/commonMain/kotlin/com/banko/app/api/HttpClientProvider.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/api/HttpClientProvider.kt
@@ -19,9 +19,13 @@ object HttpClientProvider {
             level = LogLevel.INFO
         }
         install(HttpTimeout) {
-            socketTimeoutMillis = TIMEOUT
+            connectTimeoutMillis = CONNECT_TIMEOUT
+            socketTimeoutMillis = SOCKET_TIMEOUT
+            requestTimeoutMillis = REQUEST_TIMEOUT
         }
     }
 }
 
-internal const val TIMEOUT: Long = 60_000L
+internal const val CONNECT_TIMEOUT: Long = 15_000L
+internal const val SOCKET_TIMEOUT: Long = 30_000L
+internal const val REQUEST_TIMEOUT: Long = 30_000L

--- a/composeApp/src/commonMain/kotlin/com/banko/app/api/auth/SessionManager.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/api/auth/SessionManager.kt
@@ -39,22 +39,30 @@ class SessionManager(
         }
     }
 
-    fun login(email: String, password: String) {
-        scope.launch {
-            _authState.value = AuthState.Loading
-            when (authRepository.login(email, password)) {
-                is Result.Success -> _authState.value = AuthState.Authenticated
-                is Result.Error -> _authState.value = AuthState.Unauthenticated
+    suspend fun login(email: String, password: String): Result<Unit> {
+        _authState.value = AuthState.Loading
+        return when (val result = authRepository.login(email, password)) {
+            is Result.Success -> {
+                _authState.value = AuthState.Authenticated
+                Result.Success(Unit)
+            }
+            is Result.Error -> {
+                _authState.value = AuthState.Unauthenticated
+                result
             }
         }
     }
 
-    fun register(email: String, password: String, fullName: String?, consentGiven: Boolean) {
-        scope.launch {
-            _authState.value = AuthState.Loading
-            when (authRepository.register(email, password, fullName, consentGiven)) {
-                is Result.Success -> _authState.value = AuthState.Authenticated
-                is Result.Error -> _authState.value = AuthState.Unauthenticated
+    suspend fun register(email: String, password: String, fullName: String?, consentGiven: Boolean): Result<Unit> {
+        _authState.value = AuthState.Loading
+        return when (val result = authRepository.register(email, password, fullName, consentGiven)) {
+            is Result.Success -> {
+                _authState.value = AuthState.Authenticated
+                Result.Success(Unit)
+            }
+            is Result.Error -> {
+                _authState.value = AuthState.Unauthenticated
+                result
             }
         }
     }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/api/utils/Results.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/api/utils/Results.kt
@@ -3,6 +3,7 @@ package com.banko.app.api.utils
 import io.ktor.client.HttpClient
 import io.ktor.client.call.body
 import io.ktor.client.plugins.ClientRequestException
+import io.ktor.client.plugins.HttpRequestTimeoutException
 import io.ktor.client.plugins.RedirectResponseException
 import io.ktor.client.plugins.ServerResponseException
 import io.ktor.client.request.*
@@ -71,6 +72,8 @@ suspend inline fun <reified T> HttpClient.safeRequest(
             body = try { e.response.body() } catch (e: Exception) { null }
         )
     } catch (e: UnresolvedAddressException) {
+        Result.Error.NetworkError(e)
+    } catch (e: HttpRequestTimeoutException) {
         Result.Error.NetworkError(e)
     } catch (e: SerializationException) {
         Result.Error.SerializationError(e)

--- a/composeApp/src/commonMain/kotlin/com/banko/app/data/repository/CurrencyRepository.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/data/repository/CurrencyRepository.kt
@@ -73,14 +73,20 @@ class CurrencyRepository(
                 current = current.plus(DatePeriod(days = 1))
             }
 
-            if (missingDates.isEmpty()) return@withLock cachedMap.filterValues { it != null }.mapValues { it.value!! }
+            if (missingDates.isEmpty()) {
+                val filtered = cachedMap.filterValues { it != null }.mapValues { it.value!! }
+                return@withLock fillGaps(filtered, startDate, endDate)
+            }
 
             val actualStart = missingDates.first()
             val actualEnd = missingDates.last()
 
             val result = frankfurterService.getTimeSeriesRates(fromCurrency, toCurrency, actualStart.toString(), actualEnd.toString())
             when (result) {
-                is Result.Error -> return@withLock cachedMap.filterValues { it != null }.mapValues { it.value!! }
+                is Result.Error -> {
+                    val filtered = cachedMap.filterValues { it != null }.mapValues { it.value!! }
+                    fillGaps(filtered, startDate, endDate)
+                }
                 is Result.Success -> {
                     val ratesToInsert = mutableListOf<ExchangeRate>()
                     var apiCurrent = actualStart
@@ -92,10 +98,32 @@ class CurrencyRepository(
                     }
                     exchangeRateDao.upsertExchangeRates(ratesToInsert)
                     val fetchedMap = ratesToInsert.associate { LocalDate.parse(it.date) to it.rate }
-                    (cachedMap + fetchedMap).filterValues { it != null }.mapValues { it.value!! }
+                    val merged = (cachedMap + fetchedMap).filterValues { it != null }.mapValues { it.value!! }
+                    fillGaps(merged, startDate, endDate)
                 }
             }
         }
+    }
+
+    private fun fillGaps(
+        rates: Map<LocalDate, Double>,
+        startDate: LocalDate,
+        endDate: LocalDate,
+    ): Map<LocalDate, Double> {
+        val result = mutableMapOf<LocalDate, Double>()
+        var lastRate: Double? = null
+        var current = startDate
+        while (current <= endDate) {
+            val rate = rates[current]
+            if (rate != null) {
+                lastRate = rate
+            }
+            if (lastRate != null) {
+                result[current] = lastRate
+            }
+            current = current.plus(DatePeriod(days = 1))
+        }
+        return result
     }
 
     suspend fun getRateCount(): Long = exchangeRateDao.getRateCount()

--- a/composeApp/src/commonMain/kotlin/com/banko/app/database/BankoDao.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/database/BankoDao.kt
@@ -1,6 +1,5 @@
 package com.banko.app.database
 
-import androidx.paging.PagingSource
 import androidx.room.Dao
 import androidx.room.Delete
 import androidx.room.Query

--- a/composeApp/src/commonMain/kotlin/com/banko/app/domain/AssignExpenseTagToTransactionUseCase.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/domain/AssignExpenseTagToTransactionUseCase.kt
@@ -2,9 +2,7 @@ package com.banko.app.domain
 
 import com.banko.app.DatabaseExpenseTagRepository
 import com.banko.app.DatabaseTransactionRepository
-import kotlinx.coroutines.flow.distinctUntilChanged
 import kotlinx.coroutines.flow.first
-import kotlinx.coroutines.flow.firstOrNull
 
 class AssignExpenseTagToTransactionUseCase(
     private val transactionRepository: DatabaseTransactionRepository,

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/CircularIndicator.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/CircularIndicator.kt
@@ -40,14 +40,12 @@ import androidx.compose.ui.unit.TextUnit
 import androidx.compose.ui.unit.dp
 import banko.composeapp.generated.resources.Res
 import banko.composeapp.generated.resources.expense_tag_Other
-import banko.composeapp.generated.resources.expense_tag_uncategorized
 import banko.composeapp.generated.resources.monthly_earnings
 import banko.composeapp.generated.resources.monthly_spendings
 import banko.composeapp.generated.resources.yearly_earnings
 import banko.composeapp.generated.resources.yearly_spendings
 import com.banko.app.ModelTransaction
 import com.banko.app.ui.models.Category
-import com.banko.app.ui.models.Transaction
 import com.banko.app.ui.screens.home.TimespanSelection
 import com.banko.app.ui.theme.Grey_Nevada
 import kotlinx.datetime.Month

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/ExpandableCard.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/components/ExpandableCard.kt
@@ -20,7 +20,6 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Shape
 import androidx.compose.ui.unit.dp
 import org.jetbrains.compose.resources.vectorResource
 

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/models/Category.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/models/Category.kt
@@ -1,16 +1,6 @@
 package com.banko.app.ui.models
 
 import androidx.compose.ui.graphics.Color
-import com.banko.app.ui.theme.Coral
-import com.banko.app.ui.theme.DarkMidnightBlue
-import com.banko.app.ui.theme.DarkTurquoise
-import com.banko.app.ui.theme.Firebrick
-import com.banko.app.ui.theme.MediumPurple
-import com.banko.app.ui.theme.Olive
-import com.banko.app.ui.theme.Orange
-import com.banko.app.ui.theme.PatriarchPurple
-import com.banko.app.ui.theme.SteelBlue
-import com.banko.app.ui.theme.Teal
 
 data class Category(
     val id: String?,

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/auth/AuthScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/auth/AuthScreen.kt
@@ -1,6 +1,8 @@
 package com.banko.app.ui.screens.auth
 
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import com.arkivanov.decompose.ExperimentalDecomposeApi
@@ -15,14 +17,19 @@ import com.banko.app.ui.screens.register.RegisterScreen
 @Composable
 fun AuthScreen(component: AuthComponent) {
     val childStack = component.childStack.subscribeAsState()
-    Children(
-        stack = childStack.value,
+    Surface(
         modifier = Modifier.fillMaxSize(),
-        animation = stackAnimation(slide()),
-    ) { child ->
-        when (val instance = child.instance) {
-            is AuthComponent.Child.Login -> LoginScreen(instance.component)
-            is AuthComponent.Child.Register -> RegisterScreen(instance.component)
+        color = MaterialTheme.colorScheme.surface,
+    ) {
+        Children(
+            stack = childStack.value,
+            modifier = Modifier.fillMaxSize(),
+            animation = stackAnimation(slide()),
+        ) { child ->
+            when (val instance = child.instance) {
+                is AuthComponent.Child.Login -> LoginScreen(instance.component)
+                is AuthComponent.Child.Register -> RegisterScreen(instance.component)
+            }
         }
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/banklinking/BankLinkingState.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/banklinking/BankLinkingState.kt
@@ -1,7 +1,5 @@
 package com.banko.app.ui.screens.banklinking
 
-import com.banko.app.api.dto.bankoApi.BankAccountSummaryDto
-import com.banko.app.api.dto.bankoApi.BankAuthorizationStatus
 import com.banko.app.api.dto.bankoApi.BankAuthDto
 import com.banko.app.api.dto.bankoApi.GoCardlessInstitutionDto
 import com.banko.app.api.dto.bankoApi.LinkedBankAccount

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/banklinking/BankLinkingViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/banklinking/BankLinkingViewModel.kt
@@ -3,10 +3,8 @@ package com.banko.app.ui.screens.banklinking
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.banko.app.api.dto.bankoApi.BankAuthorizationStatus
-import com.banko.app.api.dto.bankoApi.GetBankAuthorizationsResponse
 import com.banko.app.api.services.BankoApiService
 import com.banko.app.api.utils.Result
-import kotlinx.coroutines.delay
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.update

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/details/DetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/details/DetailsScreen.kt
@@ -284,7 +284,8 @@ fun DetailsScreen(
                 TextField(
                     modifier = Modifier.padding(start = 16.dp, end = 16.dp).fillMaxWidth(),
                     onValueChange = {},
-                    value = transaction.remittanceInformationUnstructuredArray.joinToString(" "),
+                    value = transaction.remittanceInformationUnstructured,
+                    minLines = 3,
                     supportingText = {
                         Text(
                             text = stringResource(Res.string.details_remittance_information)

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/details/DetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/details/DetailsScreen.kt
@@ -112,7 +112,6 @@ fun DetailsScreen(
 ) {
     var transaction by remember { mutableStateOf(transactions) }
     val transactionNote = remember { mutableStateOf(transaction.note ?: "") }
-    var oldTag by remember { mutableStateOf(transaction.expenseTag?.id) }
     val isEditing by remember { mutableStateOf(false) }
     val isEditNote = remember { mutableStateOf(false) }
     val isDeleteNote = remember { mutableStateOf(false) }
@@ -590,7 +589,6 @@ fun DetailsScreen(
                         onTagSelected = { tag ->
                             transaction = transaction.copy(expenseTag = tag)
                             assignExpenseTag(transaction.id, tag?.id)
-                            oldTag = tag?.id
                         })
                 }
             }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/details/DetailsScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/details/DetailsScreen.kt
@@ -561,7 +561,7 @@ fun DetailsScreen(
                                 },
                                 contentDescription = null,
                                 tint = transaction.expenseTag?.color
-                                    ?: MaterialTheme.colorScheme.onSurface
+                                    ?: MaterialTheme.colorScheme.primary
                             )
                         },
                         trailingIcon = {

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreen.kt
@@ -44,6 +44,7 @@ import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Card
 import androidx.compose.material3.CardDefaults
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.HorizontalDivider
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
@@ -99,6 +100,7 @@ import com.banko.app.ui.models.Transaction
 import com.banko.app.ui.components.dialogs.TransactionDeleteDialog
 import com.banko.app.domain.model.currencyDisplayForCode
 import com.banko.app.ui.utils.toUserMessage
+import com.banko.app.utils.tailDisplay
 import kotlinx.datetime.Month
 import org.jetbrains.compose.resources.painterResource
 import org.jetbrains.compose.resources.stringResource
@@ -243,7 +245,8 @@ fun HomeScreen(
                 hostState = snackbarHostState,
                 rawError = uiState.error?.fullMessage,
             )
-        }
+        },
+        containerColor = MaterialTheme.colorScheme.surface
     ) { padding ->
         Box(
             modifier = Modifier
@@ -494,14 +497,13 @@ private fun SwipableTransactionRow(
                     verticalAlignment = Alignment.CenterVertically
                 ) {
                     Text(
-                        modifier = Modifier.weight(1f),
-                        text = transaction.remittanceInformationUnstructured.replace("\\s+".toRegex(), " "),
+                        modifier = Modifier.weight(1f).padding(end = 16.dp),
+                        text = transaction.remittanceInformationUnstructured.replace("\\s+".toRegex(), " ").tailDisplay(),
                         color = MaterialTheme.colorScheme.primary,
                         overflow = TextOverflow.Ellipsis,
-                        maxLines = 1,
-                        style = MaterialTheme.typography.bodySmall
+                        maxLines = 2,
+                        style = MaterialTheme.typography.labelSmall
                     )
-                    Spacer(modifier = Modifier.width(8.dp))
                     BankLogo(
                         logoUrl = transaction.bankLogoUrl,
                         bankName = transaction.bankName,
@@ -758,14 +760,20 @@ private fun LazyTransactionList(
                         items = transactionsByDate,
                         key = { it.id }
                     ) { transaction ->
-                        SwipableTransactionRow(
-                            transaction = transaction,
-                            isOpen = openedRowId == transaction.id,
-                            onOpen = { openedRowId = transaction.id },
-                            onClose = { openedRowId = null },
-                            onClick = { navigateToDetails(transaction) },
-                            onDeleteTransaction = onDeleteTransaction
-                        )
+                        Column {
+                            SwipableTransactionRow(
+                                transaction = transaction,
+                                isOpen = openedRowId == transaction.id,
+                                onOpen = { openedRowId = transaction.id },
+                                onClose = { openedRowId = null },
+                                onClick = { navigateToDetails(transaction) },
+                                onDeleteTransaction = onDeleteTransaction
+                            )
+                            HorizontalDivider(
+                                modifier = Modifier.padding(horizontal = 12.dp),
+                                color = MaterialTheme.colorScheme.outlineVariant
+                            )
+                        }
                     }
                 }
             }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreen.kt
@@ -54,7 +54,6 @@ import androidx.compose.material3.SnackbarHostState
 import androidx.compose.material3.Switch
 import androidx.compose.material3.Surface
 import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.material3.pulltorefresh.PullToRefreshBox
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -87,7 +86,6 @@ import androidx.compose.ui.unit.Velocity
 import androidx.compose.ui.unit.dp
 import banko.composeapp.generated.resources.Res
 import banko.composeapp.generated.resources.app_name
-import banko.composeapp.generated.resources.details
 import banko.composeapp.generated.resources.ic_delete
 import banko.composeapp.generated.resources.ic_tag
 import banko.composeapp.generated.resources.ic_tag_filled
@@ -95,7 +93,6 @@ import com.banko.app.ModelTransaction
 import com.banko.app.ui.components.BankLogo
 import com.banko.app.ui.components.CircularIndicator
 import com.banko.app.ui.components.ErrorSnackbarHost
-import com.banko.app.ui.components.ExpenseTag
 import com.banko.app.ui.models.Transaction
 import com.banko.app.ui.components.dialogs.TransactionDeleteDialog
 import com.banko.app.domain.model.currencyDisplayForCode

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/home/HomeScreen.kt
@@ -544,7 +544,7 @@ private fun TopContent() {
     Column(
         modifier = Modifier
             .fillMaxWidth()
-            .padding(horizontal = 16.dp, vertical = 20.dp),
+            .padding(horizontal = 16.dp, vertical = 8.dp),
     ) {
         Text(
             text = stringResource(Res.string.app_name),

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/login/LoginScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/login/LoginScreen.kt
@@ -20,6 +20,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -68,6 +69,10 @@ fun LoginScreen(component: LoginComponent) {
             singleLine = true,
             modifier = Modifier.fillMaxWidth(),
             enabled = !state.isLoading,
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                unfocusedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            ),
         )
         Spacer(Modifier.height(12.dp))
         OutlinedTextField(
@@ -78,6 +83,10 @@ fun LoginScreen(component: LoginComponent) {
             modifier = Modifier.fillMaxWidth(),
             enabled = !state.isLoading,
             visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation,
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                unfocusedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            ),
             trailingIcon = {
                 IconButton(onClick = { passwordVisible = !passwordVisible }) {
                     Icon(

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/login/LoginScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/login/LoginScreen.kt
@@ -33,7 +33,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import banko.composeapp.generated.resources.Res
-import banko.composeapp.generated.resources.auth_error_login_failed
 import banko.composeapp.generated.resources.login_button
 import banko.composeapp.generated.resources.login_email
 import banko.composeapp.generated.resources.login_no_account
@@ -99,7 +98,7 @@ fun LoginScreen(component: LoginComponent) {
         state.error?.let {
             Spacer(Modifier.height(8.dp))
             Text(
-                text = stringResource(Res.string.auth_error_login_failed),
+                text = it,
                 color = MaterialTheme.colorScheme.error,
                 style = MaterialTheme.typography.bodySmall,
             )

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/login/LoginViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/login/LoginViewModel.kt
@@ -3,6 +3,7 @@ package com.banko.app.ui.screens.login
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.banko.app.api.auth.SessionManager
+import com.banko.app.api.utils.Result
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -37,6 +38,23 @@ class LoginViewModel(
             return
         }
         _state.update { it.copy(isLoading = true, error = null) }
-        sessionManager.login(s.email, s.password)
+        viewModelScope.launch {
+            when (val result = sessionManager.login(s.email, s.password)) {
+                is Result.Success -> _state.update { it.copy(isLoading = false) }
+                is Result.Error -> _state.update {
+                    it.copy(isLoading = false, error = errorMessageFor(result))
+                }
+            }
+        }
+    }
+
+    private fun errorMessageFor(error: Result.Error): String = when (error) {
+        is Result.Error.HttpError -> when (error.code) {
+            401, 403 -> "Wrong email and/or password."
+            in 500..599 -> "Server not responding. Check your connection and try again."
+            else -> "An unexpected error occurred. Please try again."
+        }
+        is Result.Error.NetworkError -> "Server not responding. Check your connection and try again."
+        else -> "An unexpected error occurred. Please try again."
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/register/RegisterScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/register/RegisterScreen.kt
@@ -35,7 +35,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import banko.composeapp.generated.resources.Res
-import banko.composeapp.generated.resources.auth_error_registration_failed
 import banko.composeapp.generated.resources.login_email
 import banko.composeapp.generated.resources.login_password
 import banko.composeapp.generated.resources.register_button
@@ -129,7 +128,7 @@ fun RegisterScreen(component: RegisterComponent) {
         state.error?.let {
             Spacer(Modifier.height(8.dp))
             Text(
-                text = stringResource(Res.string.auth_error_registration_failed),
+                text = it,
                 color = MaterialTheme.colorScheme.error,
                 style = MaterialTheme.typography.bodySmall,
             )

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/register/RegisterScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/register/RegisterScreen.kt
@@ -22,6 +22,7 @@ import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.OutlinedTextFieldDefaults
 import androidx.compose.material3.Text
 import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
@@ -73,6 +74,10 @@ fun RegisterScreen(component: RegisterComponent) {
             singleLine = true,
             modifier = Modifier.fillMaxWidth(),
             enabled = !state.isLoading,
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                unfocusedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            ),
         )
         Spacer(Modifier.height(12.dp))
         OutlinedTextField(
@@ -82,6 +87,10 @@ fun RegisterScreen(component: RegisterComponent) {
             singleLine = true,
             modifier = Modifier.fillMaxWidth(),
             enabled = !state.isLoading,
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                unfocusedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            ),
         )
         Spacer(Modifier.height(12.dp))
         OutlinedTextField(
@@ -92,6 +101,10 @@ fun RegisterScreen(component: RegisterComponent) {
             modifier = Modifier.fillMaxWidth(),
             enabled = !state.isLoading,
             visualTransformation = if (passwordVisible) VisualTransformation.None else PasswordVisualTransformation,
+            colors = OutlinedTextFieldDefaults.colors(
+                focusedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                unfocusedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+            ),
             trailingIcon = {
                 IconButton(onClick = { passwordVisible = !passwordVisible }) {
                     Icon(

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/register/RegisterViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/register/RegisterViewModel.kt
@@ -3,6 +3,7 @@ package com.banko.app.ui.screens.register
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.banko.app.api.auth.SessionManager
+import com.banko.app.api.utils.Result
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
 import kotlinx.coroutines.flow.asStateFlow
@@ -47,11 +48,28 @@ class RegisterViewModel(
             return
         }
         _state.update { it.copy(isLoading = true, error = null) }
-        sessionManager.register(
-            email = s.email,
-            password = s.password,
-            fullName = s.fullName.ifBlank { null },
-            consentGiven = s.consentGiven,
-        )
+        viewModelScope.launch {
+            when (val result = sessionManager.register(
+                email = s.email,
+                password = s.password,
+                fullName = s.fullName.ifBlank { null },
+                consentGiven = s.consentGiven,
+            )) {
+                is Result.Success -> _state.update { it.copy(isLoading = false) }
+                is Result.Error -> _state.update {
+                    it.copy(isLoading = false, error = errorMessageFor(result))
+                }
+            }
+        }
+    }
+
+    private fun errorMessageFor(error: Result.Error): String = when (error) {
+        is Result.Error.HttpError -> when (error.code) {
+            409 -> "An account with this email already exists."
+            in 500..599 -> "Server not responding. Check your connection and try again."
+            else -> "An unexpected error occurred. Please try again."
+        }
+        is Result.Error.NetworkError -> "Server not responding. Check your connection and try again."
+        else -> "An unexpected error occurred. Please try again."
     }
 }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/SettingsComponent.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/SettingsComponent.kt
@@ -1,7 +1,6 @@
 package com.banko.app.ui.screens.settings
 
 import com.arkivanov.decompose.ComponentContext
-import org.koin.compose.viewmodel.koinViewModel
 
 
 class SettingsComponent(

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/SettingsScreenViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/SettingsScreenViewModel.kt
@@ -17,10 +17,7 @@ import com.banko.app.ui.models.toDao
 import com.banko.app.ui.utils.ErrorState
 import com.banko.app.ui.utils.classifyError
 import kotlinx.coroutines.flow.MutableStateFlow
-import kotlinx.coroutines.flow.SharingStarted
 import kotlinx.coroutines.flow.StateFlow
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.stateIn
 import kotlinx.coroutines.flow.update
 import kotlinx.coroutines.launch
 

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/bottomsheets/LinkedBanksBottomSheetContent.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/settings/bottomsheets/LinkedBanksBottomSheetContent.kt
@@ -93,7 +93,7 @@ fun LinkedBanksBottomSheetContent(
                 Text(
                     text = stringResource(Res.string.no_linked_banks),
                     style = MaterialTheme.typography.bodyLarge,
-                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                    color = MaterialTheme.colorScheme.onSurface,
                     modifier = Modifier.padding(vertical = 24.dp),
                 )
             }
@@ -177,14 +177,14 @@ private fun BankAuthorizationRow(
                                 Text(
                                     text = stringResource(Res.string.iban_label, maskIban(iban)),
                                     style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    color = MaterialTheme.colorScheme.onSurface,
                                 )
                             }
                             account.currency?.let { currency ->
                                 Text(
                                     text = " · $currency",
                                     style = MaterialTheme.typography.bodySmall,
-                                    color = MaterialTheme.colorScheme.onSurfaceVariant,
+                                    color = MaterialTheme.colorScheme.onSurface,
                                 )
                             }
                         }

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/theme/Color.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/theme/Color.kt
@@ -84,13 +84,13 @@ val Darkmode_Primary = Color(0xBB86FCFF)
 val Darkmode_PrimaryVariant = Color(0x3700B3FF)
 val Darkmode_Secondary = Teal
 val Dark_Surface = Color(0xFF212121)
-val Dark_On_Surface = Color(0xFF303030)
+val Dark_On_Surface = Color(0xFF283031)
 
 val Brightmode_Primary = Color(0xFF6650A4)
 val Brightmode_PrimaryVariant = Color(0xFF642B73)
 val Brightmode_Secondary = DarkSlateGray
 val Light_Surface = Color(0xFFFFFFF0)
-val Light_On_Surface = Color(0xFFF2EFDE)
+val Light_On_Surface = Color(0xFFf4f3eb)
 
 val colorList: List<Color> = listOf(
     // Blues

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/theme/Theme.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/theme/Theme.kt
@@ -12,6 +12,7 @@ private val DarkColorScheme = darkColorScheme(
     tertiary = Darkmode_PrimaryVariant,
     surface = Dark_Surface,
     onSurface = Dark_On_Surface,
+    onSurfaceVariant = Light_Surface
 )
 
 private val LightColorScheme = lightColorScheme(
@@ -20,6 +21,7 @@ private val LightColorScheme = lightColorScheme(
     tertiary = Brightmode_PrimaryVariant,
     surface = Light_Surface,
     onSurface = Light_On_Surface,
+    onSurfaceVariant = Dark_Surface
 )
 
 @Composable

--- a/composeApp/src/commonMain/kotlin/com/banko/app/utils/StringUtils.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/utils/StringUtils.kt
@@ -1,0 +1,12 @@
+package com.banko.app.utils
+
+fun String.tailDisplay(maxLength: Int = 120): String {
+    if (length <= maxLength) return this
+    val tail = takeLast(maxLength)
+    val firstSpace = tail.indexOf(' ')
+    return if (firstSpace > 0) {
+        "\u2026" + tail.substring(firstSpace + 1)
+    } else {
+        "\u2026" + tail
+    }
+}

--- a/iosApp/iosApp/ContentView.swift
+++ b/iosApp/iosApp/ContentView.swift
@@ -11,9 +11,21 @@ struct ComposeView: UIViewControllerRepresentable {
 }
 
 struct ContentView: View {
+    @Environment(\.colorScheme) var colorScheme
+
+    private var surfaceColor: Color {
+        colorScheme == .dark
+            ? Color(red: 0x21/255, green: 0x21/255, blue: 0x21/255)
+            : Color(red: 0xFF/255, green: 0xFF/255, blue: 0xF0/255)
+    }
+
     var body: some View {
-        ComposeView()
-                .ignoresSafeArea(.keyboard) // Compose has own keyboard handler
+        ZStack {
+            surfaceColor
+                .ignoresSafeArea()
+            ComposeView()
+                .ignoresSafeArea(.keyboard)
+        }
     }
 }
 


### PR DESCRIPTION
## What
- Improve transaction list readability: 2-line descriptions with tail truncation, dividers, reduced top header padding
- Switch bottom navigation from Material 2 to Material 3 NavigationBar with theme-consistent colors
- Fix system bar and screen backgrounds to follow theme surface color (Android edge-to-edge + iOS ZStack)
- Fix login/register screen backgrounds and input text color to follow theme
- Fix current month currency conversion by carrying forward most recent available rate for missing dates
- Add swipe-to-go-back gesture on main navigation (left edge drag)
- Add login/register error handling with user-friendly messages (wrong credentials, server errors, timeouts)
- Add HTTP client timeout configuration (connect 15s, socket 30s, request 30s)
- Remove unused imports and dead code across 13 files

## Why
- Transaction descriptions were single-line and hard to read, especially for verbose Italian bank descriptions
- Material 2 BottomNavigation did not respect Material 3 theme colors, causing inconsistent bottom nav appearance
- System bar backgrounds were white/dark regardless of theme, breaking visual consistency
- Login/register screens had default backgrounds and input text that ignored the theme
- Currency conversion failed for current month dates where Frankfurter API had no rates yet, causing mixed-currency summaries
- No swipe-back gesture existed, forcing users to rely on back buttons
- Login/register errors left users stuck on loading screens with no feedback
- No HTTP timeouts caused indefinite loading on server issues