### PR TITLE
Split register full name field into name and surname

### DIFF
--- a/composeApp/src/commonMain/composeResources/values/strings.xml
+++ b/composeApp/src/commonMain/composeResources/values/strings.xml
@@ -82,7 +82,8 @@
     <string name="login_no_account">Don't have an account?</string>
     <string name="login_register_link">Register</string>
     <string name="register_title">Create Account</string>
-    <string name="register_full_name">Full Name</string>
+    <string name="register_name">Name</string>
+    <string name="register_surname">Surname</string>
     <string name="register_consent">I agree to the privacy policy</string>
     <string name="register_button">Create Account</string>
     <string name="register_has_account">Already have an account?</string>

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/register/RegisterScreen.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/register/RegisterScreen.kt
@@ -2,6 +2,7 @@ package com.banko.app.ui.screens.register
 
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
@@ -39,7 +40,8 @@ import banko.composeapp.generated.resources.login_email
 import banko.composeapp.generated.resources.login_password
 import banko.composeapp.generated.resources.register_button
 import banko.composeapp.generated.resources.register_consent
-import banko.composeapp.generated.resources.register_full_name
+import banko.composeapp.generated.resources.register_name
+import banko.composeapp.generated.resources.register_surname
 import banko.composeapp.generated.resources.register_has_account
 import banko.composeapp.generated.resources.register_login_link
 import banko.composeapp.generated.resources.register_title
@@ -66,18 +68,35 @@ fun RegisterScreen(component: RegisterComponent) {
             color = MaterialTheme.colorScheme.primary,
         )
         Spacer(Modifier.height(32.dp))
-        OutlinedTextField(
-            value = state.fullName,
-            onValueChange = viewModel::onFullNameChanged,
-            label = { Text(stringResource(Res.string.register_full_name)) },
-            singleLine = true,
+        Row(
             modifier = Modifier.fillMaxWidth(),
-            enabled = !state.isLoading,
-            colors = OutlinedTextFieldDefaults.colors(
-                focusedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
-                unfocusedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
-            ),
-        )
+            horizontalArrangement = Arrangement.spacedBy(12.dp),
+        ) {
+            OutlinedTextField(
+                value = state.name,
+                onValueChange = viewModel::onNameChanged,
+                label = { Text(stringResource(Res.string.register_name)) },
+                singleLine = true,
+                modifier = Modifier.weight(1f),
+                enabled = !state.isLoading,
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    unfocusedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                ),
+            )
+            OutlinedTextField(
+                value = state.surname,
+                onValueChange = viewModel::onSurnameChanged,
+                label = { Text(stringResource(Res.string.register_surname)) },
+                singleLine = true,
+                modifier = Modifier.weight(1f),
+                enabled = !state.isLoading,
+                colors = OutlinedTextFieldDefaults.colors(
+                    focusedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                    unfocusedTextColor = MaterialTheme.colorScheme.onSurfaceVariant,
+                ),
+            )
+        }
         Spacer(Modifier.height(12.dp))
         OutlinedTextField(
             value = state.email,
@@ -123,7 +142,7 @@ fun RegisterScreen(component: RegisterComponent) {
                 onCheckedChange = viewModel::onConsentChanged,
                 enabled = !state.isLoading,
             )
-            Text(stringResource(Res.string.register_consent))
+            Text(stringResource(Res.string.register_consent), color = MaterialTheme.colorScheme.primary)
         }
         state.error?.let {
             Spacer(Modifier.height(8.dp))

--- a/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/register/RegisterViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/com/banko/app/ui/screens/register/RegisterViewModel.kt
@@ -13,7 +13,8 @@ import kotlinx.coroutines.launch
 data class RegisterScreenState(
     val email: String = "",
     val password: String = "",
-    val fullName: String = "",
+    val name: String = "",
+    val surname: String = "",
     val consentGiven: Boolean = false,
     val isLoading: Boolean = false,
     val error: String? = null,
@@ -33,8 +34,12 @@ class RegisterViewModel(
         _state.update { it.copy(password = value, error = null) }
     }
 
-    fun onFullNameChanged(value: String) {
-        _state.update { it.copy(fullName = value, error = null) }
+    fun onNameChanged(value: String) {
+        _state.update { it.copy(name = value, error = null) }
+    }
+
+    fun onSurnameChanged(value: String) {
+        _state.update { it.copy(surname = value, error = null) }
     }
 
     fun onConsentChanged(value: Boolean) {
@@ -43,16 +48,17 @@ class RegisterViewModel(
 
     fun register() {
         val s = _state.value
-        if (s.email.isBlank() || s.password.isBlank()) {
+        if (s.email.isBlank() || s.password.isBlank() || s.name.isBlank() || s.surname.isBlank()) {
             _state.update { it.copy(error = "Please fill in all fields.") }
             return
         }
         _state.update { it.copy(isLoading = true, error = null) }
         viewModelScope.launch {
+            val fullName = "${s.surname} ${s.name}"
             when (val result = sessionManager.register(
                 email = s.email,
                 password = s.password,
-                fullName = s.fullName.ifBlank { null },
+                fullName = fullName,
                 consentGiven = s.consentGiven,
             )) {
                 is Result.Success -> _state.update { it.copy(isLoading = false) }


### PR DESCRIPTION
## What

- Replace the single Full Name field in the register screen with separate Name and Surname fields displayed side by side
- Both fields are required; composed as "Surname Name" before sending to the API
- Apply primary color to the consent text

## Why

- A single full name field is ambiguous for users with different naming conventions
- Splitting into name and surname provides clearer input expectations and better data quality for the backend
- Consent text was visually receding; primary color draws attention to the privacy policy agreement